### PR TITLE
bump pnpm to 10.33 and enable trust-policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "vite-tsconfig-paths": "^5.0.1",
         "vitest": "^4.0.18"
     },
-    "packageManager": "pnpm@10.17.1",
+    "packageManager": "pnpm@10.33.0",
     "pnpm": {
         "overrides": {
             "vite": "^8.0.3"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - apps/*
   - packages/*
 
+trustPolicy: no-downgrade
+
 onlyBuiltDependencies:
   - '@biomejs/biome'
   - esbuild


### PR DESCRIPTION
Bumps pnpm and enables pnpm's `trustPolicy: no-downgrade` across the workspace to catch future supply-chain downgrades, as happened and was reported in #75.