### PR TITLE
feat: global prefix for CSS variables

### DIFF
--- a/.changeset/misty-otters-hum.md
+++ b/.changeset/misty-otters-hum.md
@@ -1,0 +1,20 @@
+---
+"@sugarcube-sh/core": patch
+"@sugarcube-sh/cli": patch
+"@sugarcube-sh/vite": patch
+---
+
+Add `variables.prefix` and `variables.variableName` config options for controlling generated CSS variable names.
+
+**`@sugarcube-sh/core`**
+
+- New `variables.prefix` option: prepends a string to every generated CSS variable name (e.g. `prefix: "ds"` → `--ds-color-brand-primary`). Flows through declarations, `var(--…)` references, and utility-class output automatically.
+- New `variables.variableName` option: `(path: string) => string` callback for full control over naming. Overrides `prefix` when both are set. Useful for kebab-casing, custom separators, etc.
+- Export `kebabCase(str)` helper. Shipped as a convenience for users.
+- Export `createVariableNameResolver(variables)` — builds a bound resolver function from a `variables` config, for consumers (Studio, external tools) that need to construct `var(--…)` strings matching emitted CSS.
+- Export `VariableNameFn` type.
+- Internal: CSS variable names are now computed once per token during the convert step and stored on `token.$names.css`. Declarations, references (`{color.primary}` -> `var(--…)`), and utility-class rules all read from this single source — eliminating a latent bug where references with camelCase path segments (e.g. `{color.brandPrimary}`) produced names that didn't match their declarations.
+
+**`@sugarcube-sh/cli`, `@sugarcube-sh/vite`**
+
+- Re-export `kebabCase` and the `VariableNameFn` type so users can import everything they need from whichever entry point they already use.

--- a/.changeset/misty-otters-hum.md
+++ b/.changeset/misty-otters-hum.md
@@ -15,6 +15,11 @@ Add `variables.prefix` and `variables.variableName` config options for controlli
 - Export `VariableNameFn` type.
 - Internal: CSS variable names are now computed once per token during the convert step and stored on `token.$names.css`. Declarations, references (`{color.primary}` -> `var(--…)`), and utility-class rules all read from this single source — eliminating a latent bug where references with camelCase path segments (e.g. `{color.brandPrimary}`) produced names that didn't match their declarations.
 
-**`@sugarcube-sh/cli`, `@sugarcube-sh/vite`**
+**`@sugarcube-sh/cli`**
+
+- New `--prefix <string>` flag on `sugarcube generate`. Mirrors `variables.prefix` so users can prepend a CSS variable prefix without needing a config file. Pass the prefix without the leading `--` (e.g. `--prefix ds` produces `--ds-color-foo`). Overrides `variables.prefix` if a config file is present.
+- Re-export `kebabCase` and the `VariableNameFn` type.
+
+**`@sugarcube-sh/vite`**
 
 - Re-export `kebabCase` and the `VariableNameFn` type so users can import everything they need from whichever entry point they already use.

--- a/apps/www/src/content/docs/docs/configuration.mdx
+++ b/apps/www/src/content/docs/docs/configuration.mdx
@@ -92,6 +92,39 @@ export default defineConfig({
 For more on fluid spacing and typography in sugarcube, see [fluid spacing and typography](/docs/fluid-space-and-type).
 
 
+## Prefixing CSS variable names
+
+Add a prefix to all generated CSS variables. Useful for scoping variables to your design system and tracking adoption across a codebase.
+
+```ts title="sugarcube.config.ts" ins={5}
+import { defineConfig } from "@sugarcube-sh/cli";
+
+export default defineConfig({
+  variables: {
+    prefix: "ds"
+  }
+});
+```
+
+With `prefix: "ds"`, a token at `color.brand.primary` becomes `--ds-color-brand-primary`. The prefix flows through declarations, references (`var(--ds-…)`), and generated utility classes automatically.
+
+### Full control with `variableName`
+
+For anything beyond a simple prefix (e.g. casing, custom separators), provide a `variableName` callback. It receives the token path and returns the variable name (without the leading `--`).
+
+```ts title="sugarcube.config.ts" ins={5}
+import { defineConfig, kebabCase } from "@sugarcube-sh/cli";
+
+export default defineConfig({
+  variables: {
+    variableName: (path) => `ds-${kebabCase(path.replaceAll(".", "-"))}`
+  }
+});
+```
+
+`variableName` overrides `prefix` entirely when both are set.
+
+
 ## CSS Cascade Layers
 
 When using the CLI, you can wrap generated CSS in `@layer` blocks:

--- a/apps/www/src/content/docs/docs/reference/configuration-schema.mdx
+++ b/apps/www/src/content/docs/docs/reference/configuration-schema.mdx
@@ -81,6 +81,44 @@ export default defineConfig({
 });
 ```
 
+### `variables.prefix`
+
+**Type:** `string`
+**Optional**
+
+Prepended to every generated CSS variable name. Flows through declarations, references, and utility classes.
+
+```ts
+import { defineConfig } from "@sugarcube-sh/vite";
+
+export default defineConfig({
+  variables: {
+    prefix: "ds"
+  }
+});
+```
+
+With `prefix: "ds"`, a token at `color.brand.primary` produces `--ds-color-brand-primary`. Case is preserved from the source token path — use `variableName` for case transforms.
+
+### `variables.variableName`
+
+**Type:** `(path: string) => string`
+**Optional**
+
+Full-control callback for computing the CSS variable name from a token path. Receives the DTCG path, returns the name (without the leading `--`). Overrides `prefix` entirely when set.
+
+```ts
+import { defineConfig, kebabCase } from "@sugarcube-sh/vite";
+
+export default defineConfig({
+  variables: {
+    variableName: (path) => `ds-${kebabCase(path.replaceAll(".", "-"))}`
+  }
+});
+```
+
+The `kebabCase` helper is exported from `@sugarcube-sh/cli` and `@sugarcube-sh/vite`.
+
 ### `variables.layer`
 
 **Type:** `string`

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -48,6 +48,7 @@ interface GenerateFlags {
     fluidMin?: string;
     fluidMax?: string;
     colorFallback?: ColorFallbackStrategy;
+    prefix?: string;
     input?: string[];
     selector?: string;
     variablesOnly?: boolean;
@@ -116,6 +117,7 @@ function buildConfigFromFlags(flags: GenerateFlags): InternalConfig {
         resolver: flags.resolver,
         variables: {
             path: flags.variables,
+            prefix: flags.prefix,
             transforms: {
                 fluid: buildFluidConfig(flags),
                 colorFallbackStrategy: flags.colorFallback,
@@ -136,6 +138,7 @@ function mergeConfigWithFlags(config: InternalConfig, flags: GenerateFlags): Int
         variables: {
             ...config.variables,
             path: flags.variables ?? config.variables.path,
+            prefix: flags.prefix ?? config.variables.prefix,
             transforms: {
                 fluid: {
                     min: parseFluidValue(flags.fluidMin, config.variables.transforms.fluid.min),
@@ -161,7 +164,8 @@ function hasConfigFlags(flags: GenerateFlags): boolean {
         flags.utilities ||
         flags.fluidMin ||
         flags.fluidMax ||
-        flags.colorFallback
+        flags.colorFallback ||
+        flags.prefix
     );
 }
 
@@ -426,6 +430,7 @@ export const generate = new Command()
         "--color-fallback <strategy>",
         "Color fallback strategy: 'native' or 'polyfill' (default: native)"
     )
+    .option("--prefix <string>", "Prefix prepended to every generated CSS variable name")
     .option(
         "--input <modifier=value>",
         "Select a modifier context for this build (repeatable)",

--- a/packages/cli/src/exports.ts
+++ b/packages/cli/src/exports.ts
@@ -1,2 +1,2 @@
-export { defineConfig } from "@sugarcube-sh/core";
-export type { SugarcubeConfig } from "@sugarcube-sh/core";
+export { defineConfig, kebabCase } from "@sugarcube-sh/core";
+export type { SugarcubeConfig, VariableNameFn } from "@sugarcube-sh/core";

--- a/packages/cli/tests/e2e/generate.test.ts
+++ b/packages/cli/tests/e2e/generate.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execaCommand } from "execa";
@@ -67,5 +67,26 @@ describe("generate command", () => {
 
         expect(result.exitCode).toBe(0);
         expect(existsSync(join(testDir, "custom/css/tokens.css"))).toBe(true);
+    });
+
+    it("respects --prefix flag", { timeout: TEST_TIMEOUT }, async () => {
+        const tokensDir = await createTokens(testDir);
+
+        const result = await execaCommand(
+            `node ${CLI_PATH} generate --resolver ${tokensDir}/tokens.resolver.json --prefix ds`,
+            {
+                cwd: testDir,
+                timeout: TEST_TIMEOUT,
+                reject: false,
+            }
+        );
+
+        expect(result.exitCode).toBe(0);
+        const css = await readFile(join(testDir, "styles/variables.gen.css"), "utf-8");
+        const declared = [...css.matchAll(/^\s*(--[\w-]+):/gm)].map((m) => m[1]);
+        expect(declared.length).toBeGreaterThan(0);
+        for (const name of declared) {
+            expect(name).toMatch(/^--ds-/);
+        }
     });
 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -32,6 +32,8 @@ export { convertConfigToUnoRules, clearMatchCache } from "./shared/uno-rules.js"
 
 // Formatting helpers
 export { formatCSSVarName } from "./shared/format-css-var-name.js";
+export { createVariableNameResolver } from "./shared/resolve-variable-name.js";
+export { kebabCase } from "./shared/case.js";
 
 // Guards
 export { isResolvedToken } from "./shared/guards.js";
@@ -56,6 +58,7 @@ export type {
     ScaleBinding,
     ScaleLinkedBinding,
     PaletteSwapBinding,
+    VariableNameFn,
 } from "./types/config.js";
 export type {
     PipelineContext,

--- a/packages/core/src/shared/case.ts
+++ b/packages/core/src/shared/case.ts
@@ -2,7 +2,8 @@
  * Convert a string to kebab-case. Handles camelCase, PascalCase, and
  * consecutive capitals (e.g. `XMLParser` → `xml-parser`).
  *
- * Shipped so users migrating from Style Dictionary can write:
+ * Useful inside `variables.variableName` when you want kebab-cased output
+ * regardless of how the source token paths are cased.
  *
  * @example
  *   variableName: (path) => `ds-${kebabCase(path.replaceAll(".", "-"))}`

--- a/packages/core/src/shared/case.ts
+++ b/packages/core/src/shared/case.ts
@@ -1,0 +1,16 @@
+/**
+ * Convert a string to kebab-case. Handles camelCase, PascalCase, and
+ * consecutive capitals (e.g. `XMLParser` → `xml-parser`).
+ *
+ * Shipped so users migrating from Style Dictionary can write:
+ *
+ * @example
+ *   variableName: (path) => `ds-${kebabCase(path.replaceAll(".", "-"))}`
+ *   // color.brandPrimary → --ds-color-brand-primary
+ */
+export function kebabCase(str: string): string {
+    return str
+        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+        .replace(/([A-Z])([A-Z])(?=[a-z])/g, "$1-$2")
+        .toLowerCase();
+}

--- a/packages/core/src/shared/config.ts
+++ b/packages/core/src/shared/config.ts
@@ -61,6 +61,7 @@ export function fillDefaultsCore(userConfig: SugarcubeConfig, dirs: DefaultDirs)
         variables: {
             path: userConfig.variables?.path ?? defaultVariablesPath,
             prefix: userConfig.variables?.prefix,
+            variableName: userConfig.variables?.variableName,
             layer: userConfig.variables?.layer,
             transforms: {
                 fluid:

--- a/packages/core/src/shared/config.ts
+++ b/packages/core/src/shared/config.ts
@@ -60,6 +60,7 @@ export function fillDefaultsCore(userConfig: SugarcubeConfig, dirs: DefaultDirs)
 
         variables: {
             path: userConfig.variables?.path ?? defaultVariablesPath,
+            prefix: userConfig.variables?.prefix,
             layer: userConfig.variables?.layer,
             transforms: {
                 fluid:

--- a/packages/core/src/shared/pipeline/apply-converters.ts
+++ b/packages/core/src/shared/pipeline/apply-converters.ts
@@ -10,12 +10,12 @@ import type { NormalizedTokens } from "../../types/normalize.js";
 import type { ResolvedToken, ResolvedTokens } from "../../types/resolve.js";
 import type { TokenType, TokenValue } from "../../types/tokens.js";
 import { converters } from "../converters/index.js";
-import { resolveVariableName } from "../resolve-variable-name.js";
+import { createVariableNameResolver } from "../resolve-variable-name.js";
 
 function convertSingleToken<T extends TokenType>(
     token: ResolvedToken<T>,
     options: ConversionOptions,
-    config: InternalConfig
+    varName: (path: string) => string
 ): ConvertedToken<T> {
     const converter = converters[token.$type] as TokenConverter<T>;
 
@@ -32,13 +32,14 @@ function convertSingleToken<T extends TokenType>(
         $originalPath: token.$originalPath,
         $resolvedValue: token.$resolvedValue,
         $cssProperties: converter(token.$value as TokenValue<T>, options),
-        $names: { css: resolveVariableName(token.$path, config) },
+        $names: { css: varName(token.$path) },
     };
 }
 
 function convertContext(
     tokens: ResolvedTokens,
     config: InternalConfig,
+    varName: (path: string) => string,
     isTokenInvalid?: (tokenPath: string) => boolean
 ): ConvertedTokens {
     const converted: ConvertedTokens = {};
@@ -71,7 +72,7 @@ function convertContext(
             extensions: token.$extensions,
         };
 
-        converted[key] = convertSingleToken(token, options, config);
+        converted[key] = convertSingleToken(token, options, varName);
     }
 
     return converted;
@@ -122,9 +123,11 @@ export function applyConverters(
     isTokenInvalid?: (tokenPath: string) => boolean
 ): NormalizedConvertedTokens {
     const converted: NormalizedConvertedTokens = {};
+    // Bind once for perf! If you change this, you need to run a benchmark.
+    const varName = createVariableNameResolver(config.variables);
 
     for (const [context, contextTokens] of Object.entries(tokens)) {
-        converted[context] = convertContext(contextTokens, config, isTokenInvalid);
+        converted[context] = convertContext(contextTokens, config, varName, isTokenInvalid);
     }
 
     return converted;

--- a/packages/core/src/shared/pipeline/apply-converters.ts
+++ b/packages/core/src/shared/pipeline/apply-converters.ts
@@ -10,11 +10,12 @@ import type { NormalizedTokens } from "../../types/normalize.js";
 import type { ResolvedToken, ResolvedTokens } from "../../types/resolve.js";
 import type { TokenType, TokenValue } from "../../types/tokens.js";
 import { converters } from "../converters/index.js";
-import { formatCSSVarName } from "../format-css-var-name.js";
+import { resolveVariableName } from "../resolve-variable-name.js";
 
 function convertSingleToken<T extends TokenType>(
     token: ResolvedToken<T>,
-    options: ConversionOptions
+    options: ConversionOptions,
+    config: InternalConfig
 ): ConvertedToken<T> {
     const converter = converters[token.$type] as TokenConverter<T>;
 
@@ -31,7 +32,7 @@ function convertSingleToken<T extends TokenType>(
         $originalPath: token.$originalPath,
         $resolvedValue: token.$resolvedValue,
         $cssProperties: converter(token.$value as TokenValue<T>, options),
-        $names: { css: formatCSSVarName(token.$path) },
+        $names: { css: resolveVariableName(token.$path, config) },
     };
 }
 
@@ -70,7 +71,7 @@ function convertContext(
             extensions: token.$extensions,
         };
 
-        converted[key] = convertSingleToken(token, options);
+        converted[key] = convertSingleToken(token, options, config);
     }
 
     return converted;

--- a/packages/core/src/shared/pipeline/apply-converters.ts
+++ b/packages/core/src/shared/pipeline/apply-converters.ts
@@ -10,6 +10,7 @@ import type { NormalizedTokens } from "../../types/normalize.js";
 import type { ResolvedToken, ResolvedTokens } from "../../types/resolve.js";
 import type { TokenType, TokenValue } from "../../types/tokens.js";
 import { converters } from "../converters/index.js";
+import { formatCSSVarName } from "../format-css-var-name.js";
 
 function convertSingleToken<T extends TokenType>(
     token: ResolvedToken<T>,
@@ -30,6 +31,7 @@ function convertSingleToken<T extends TokenType>(
         $originalPath: token.$originalPath,
         $resolvedValue: token.$resolvedValue,
         $cssProperties: converter(token.$value as TokenValue<T>, options),
+        $names: { css: formatCSSVarName(token.$path) },
     };
 }
 

--- a/packages/core/src/shared/pipeline/format-css-variables.ts
+++ b/packages/core/src/shared/pipeline/format-css-variables.ts
@@ -20,21 +20,6 @@ function deterministicEntries<T>(obj: Record<string, T>): [string, T][] {
     return Object.entries(obj).sort(([a], [b]) => a.localeCompare(b));
 }
 
-const kebabCache = new Map<string, string>();
-
-function toKebabCase(str: string): string {
-    const cached = kebabCache.get(str);
-    if (cached) return cached;
-
-    const kebab = str
-        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-        .replace(/([A-Z])([A-Z])(?=[a-z])/g, "$1-$2")
-        .toLowerCase();
-
-    kebabCache.set(str, kebab);
-    return kebab;
-}
-
 function indentCSS(css: string, spaces = 4): string {
     const indent = " ".repeat(spaces);
     return css
@@ -43,12 +28,25 @@ function indentCSS(css: string, spaces = 4): string {
         .join("\n");
 }
 
+// Build a path → CSS var name lookup for a permutation's tokens.
+// Used by reference resolution so `{color.primary}` emits the token's
+// canonical $names.css, keeping declarations and references in sync.
+function buildNameLookup(tokens: ConvertedTokens): Map<string, string> {
+    const lookup = new Map<string, string>();
+    for (const entry of Object.values(tokens)) {
+        if ("$path" in entry && "$names" in entry) {
+            lookup.set(entry.$path, entry.$names.css);
+        }
+    }
+    return lookup;
+}
+
 // Converts token references like "{color.primary}" to CSS variable syntax
 // Preserves numbers as-is since they're valid CSS values (e.g. for font weights)
-// A trailing .$root is dropped per DTCG 2025.10 §6.2 — {blue.$root} emits var(--blue).
-const ROOT_REF_SUFFIX = ".$root";
-
-function convertReferenceToCSSVar(value: unknown): string | number {
+function convertReferenceToCSSVar(
+    value: unknown,
+    nameLookup: Map<string, string>
+): string | number {
     if (typeof value === "number") {
         return value;
     }
@@ -57,40 +55,46 @@ function convertReferenceToCSSVar(value: unknown): string | number {
         throw new Error(ErrorMessages.GENERATE.INVALID_CSS_VALUE_TYPE(typeof value));
     }
 
-    return value.replace(/\{([^}]+)\}/g, (_, ref: string) => {
-        const normalized = ref.endsWith(ROOT_REF_SUFFIX)
-            ? ref.slice(0, -ROOT_REF_SUFFIX.length)
-            : ref;
-        const varName = normalized.split(".").map(toKebabCase).join("-");
+    return value.replace(/\{([^}]+)\}/g, (_, ref) => {
+        const varName = nameLookup.get(ref) ?? formatCSSVarName(ref);
         return `var(--${varName})`;
     });
 }
 
-function generateSingleVariable(token: ConvertedToken<TokenType>): CSSVariable | undefined {
+function generateSingleVariable(
+    token: ConvertedToken<TokenType>,
+    nameLookup: Map<string, string>
+): CSSVariable | undefined {
     const props = token.$cssProperties;
     if (!("value" in props)) {
         return undefined;
     }
 
     return {
-        name: `--${formatCSSVarName(token.$path)}`,
-        value: convertReferenceToCSSVar(props.value),
+        name: `--${token.$names.css}`,
+        value: convertReferenceToCSSVar(props.value, nameLookup),
     };
 }
 
-function generateTypographyVariables(token: ConvertedToken<"typography">): CSSVariable[] {
+function generateTypographyVariables(
+    token: ConvertedToken<"typography">,
+    nameLookup: Map<string, string>
+): CSSVariable[] {
     return Object.entries(token.$cssProperties)
         .filter(([_, value]) => value !== undefined)
         .map(([prop, value]) => ({
-            name: `--${formatCSSVarName(token.$path)}-${prop}`,
-            value: convertReferenceToCSSVar(value),
+            name: `--${token.$names.css}-${prop}`,
+            value: convertReferenceToCSSVar(value, nameLookup),
         }));
 }
 
 // Color tokens can have enhanced values for displays that support modern color spaces
 // This function extracts those enhanced values and creates CSS variables that will only be used
 // when the display supports the specific color space
-function generateFeatureVariables(token: ConvertedToken<TokenType>): CSSFeatureBlock[] {
+function generateFeatureVariables(
+    token: ConvertedToken<TokenType>,
+    nameLookup: Map<string, string>
+): CSSFeatureBlock[] {
     if (token.$type !== "color") return [];
 
     const props = token.$cssProperties;
@@ -105,8 +109,8 @@ function generateFeatureVariables(token: ConvertedToken<TokenType>): CSSFeatureB
         const vars = queryGroups.get(feature.query);
         if (vars) {
             vars.push({
-                name: `--${formatCSSVarName(token.$path)}`,
-                value: convertReferenceToCSSVar(feature.value),
+                name: `--${token.$names.css}`,
+                value: convertReferenceToCSSVar(feature.value, nameLookup),
             });
         }
     }
@@ -139,18 +143,21 @@ function generateCSSBlock(block: { selector: string | string[]; vars: CSSVariabl
     return parts.join("\n");
 }
 
-function generateVariablesForToken<T extends TokenType>(token: ConvertedToken<T>): CSSVarSet {
+function generateVariablesForToken<T extends TokenType>(
+    token: ConvertedToken<T>,
+    nameLookup: Map<string, string>
+): CSSVarSet {
     if (isTypographyToken(token)) {
         return {
-            vars: generateTypographyVariables(token),
-            features: generateFeatureVariables(token),
+            vars: generateTypographyVariables(token, nameLookup),
+            features: generateFeatureVariables(token, nameLookup),
         };
     }
 
-    const mainVar = generateSingleVariable(token);
+    const mainVar = generateSingleVariable(token, nameLookup);
     return {
         vars: mainVar ? [mainVar] : [],
-        features: generateFeatureVariables(token),
+        features: generateFeatureVariables(token, nameLookup),
     };
 }
 
@@ -161,9 +168,12 @@ function generateVariablesFromTokens(tokens: ConvertedTokens): {
     vars: CSSVariable[];
     features: CSSFeatureBlock[];
 } {
+    const nameLookup = buildNameLookup(tokens);
     const varSets = deterministicEntries(tokens)
         .filter(([key, token]) => key !== "$extensions" && "$type" in token)
-        .map(([_, token]) => generateVariablesForToken(token as ConvertedToken<TokenType>));
+        .map(([_, token]) =>
+            generateVariablesForToken(token as ConvertedToken<TokenType>, nameLookup)
+        );
 
     const vars = varSets.flatMap((set) => set.vars);
 

--- a/packages/core/src/shared/pipeline/format-css-variables.ts
+++ b/packages/core/src/shared/pipeline/format-css-variables.ts
@@ -28,9 +28,10 @@ function indentCSS(css: string, spaces = 4): string {
         .join("\n");
 }
 
-// Build a path → CSS var name lookup for a permutation's tokens.
-// Used by reference resolution so `{color.primary}` emits the token's
-// canonical $names.css, keeping declarations and references in sync.
+// Map each token's path to its CSS variable name. When emitting values,
+// a reference like `{color.primary}` looks up its target here to produce
+// `var(--color-primary)` — the same name the token's declaration uses,
+// so they can't drift apart.
 function buildNameLookup(tokens: ConvertedTokens): Map<string, string> {
     const lookup = new Map<string, string>();
     for (const entry of Object.values(tokens)) {

--- a/packages/core/src/shared/resolve-variable-name.ts
+++ b/packages/core/src/shared/resolve-variable-name.ts
@@ -1,4 +1,4 @@
-import type { InternalConfig, VariableNameFn } from "../types/config.js";
+import type { VariableNameFn } from "../types/config.js";
 import { formatCSSVarName } from "./format-css-var-name.js";
 
 /** Subset of config needed to resolve a variable name — works against both user and internal configs. */
@@ -8,29 +8,21 @@ type VariablesNameConfig = {
 };
 
 /**
- * Resolve the CSS variable name for a token path, honouring the user's
- * `variables.prefix` and `variables.variableName` config. Called once per
- * token during the pipeline and stored on `token.$names.css` — every
- * emission site (declarations, references, utility classes) reads that
- * cached name.
+ * Build a reusable CSS variable-name resolver from a `variables` config.
+ *
+ * Bind once, call many times. Used by the pipeline (once at the start of
+ * the render pass, then per token) and by consumers like Studio that
+ * repeatedly build `var(--…)` strings and want names guaranteed to match
+ * the pipeline's emitted CSS.
  *
  * Resolution order:
- *   1. If `variableName` is set, it owns everything — `prefix` is ignored.
- *   2. Otherwise, `prefix` is prepended to the default path → hyphen form.
- *   3. Otherwise, default: dots become hyphens, case preserved.
+ *   1. `variableName` callback — owns everything. `prefix` is ignored.
+ *   2. `prefix` — prepended to the default path → hyphen form.
+ *   3. Default — dots become hyphens, case preserved.
  *
- * This function is the single source of truth for CSS variable naming.
- */
-export function resolveVariableName(path: string, config: InternalConfig): string {
-    return createVariableNameResolver(config.variables)(path);
-}
-
-/**
- * Build a reusable variable-name resolver from a `variables` config.
- *
- * Bind once, call many times. Useful for consumers (Studio, external tools)
- * that repeatedly build `var(--…)` strings and want names guaranteed to
- * match the pipeline's emitted CSS.
+ * This is the single source of truth for CSS variable naming. Every
+ * emission site (declarations, references, utility classes) goes through
+ * this function.
  *
  * @example
  *   const varName = createVariableNameResolver(config.variables);

--- a/packages/core/src/shared/resolve-variable-name.ts
+++ b/packages/core/src/shared/resolve-variable-name.ts
@@ -3,16 +3,21 @@ import { formatCSSVarName } from "./format-css-var-name.js";
 
 /**
  * Resolve the CSS variable name for a token path, honouring the user's
- * `variables.prefix` config. Called once per token during the pipeline
- * and stored on `token.$names.css` — every emission site (declarations,
- * references, utility classes) reads that cached name.
+ * `variables.prefix` and `variables.variableName` config. Called once per
+ * token during the pipeline and stored on `token.$names.css` — every
+ * emission site (declarations, references, utility classes) reads that
+ * cached name.
+ *
+ * Resolution order:
+ *   1. If `variableName` is set, it owns everything — `prefix` is ignored.
+ *   2. Otherwise, `prefix` is prepended to the default path → hyphen form.
+ *   3. Otherwise, default: dots become hyphens, case preserved.
  *
  * This function is the single source of truth for CSS variable naming.
- * Extend it here to change how names are produced; callers do not need
- * to know about the rules.
  */
 export function resolveVariableName(path: string, config: InternalConfig): string {
+    const { prefix, variableName } = config.variables;
+    if (variableName) return variableName(path);
     const base = formatCSSVarName(path);
-    const { prefix } = config.variables;
     return prefix ? `${prefix}-${base}` : base;
 }

--- a/packages/core/src/shared/resolve-variable-name.ts
+++ b/packages/core/src/shared/resolve-variable-name.ts
@@ -1,5 +1,11 @@
-import type { InternalConfig } from "../types/config.js";
+import type { InternalConfig, VariableNameFn } from "../types/config.js";
 import { formatCSSVarName } from "./format-css-var-name.js";
+
+/** Subset of config needed to resolve a variable name — works against both user and internal configs. */
+type VariablesNameConfig = {
+    prefix?: string;
+    variableName?: VariableNameFn;
+};
 
 /**
  * Resolve the CSS variable name for a token path, honouring the user's
@@ -16,8 +22,28 @@ import { formatCSSVarName } from "./format-css-var-name.js";
  * This function is the single source of truth for CSS variable naming.
  */
 export function resolveVariableName(path: string, config: InternalConfig): string {
-    const { prefix, variableName } = config.variables;
-    if (variableName) return variableName(path);
-    const base = formatCSSVarName(path);
-    return prefix ? `${prefix}-${base}` : base;
+    return createVariableNameResolver(config.variables)(path);
+}
+
+/**
+ * Build a reusable variable-name resolver from a `variables` config.
+ *
+ * Bind once, call many times. Useful for consumers (Studio, external tools)
+ * that repeatedly build `var(--…)` strings and want names guaranteed to
+ * match the pipeline's emitted CSS.
+ *
+ * @example
+ *   const varName = createVariableNameResolver(config.variables);
+ *   varName("color.primary"); // → "ds-color-primary"
+ */
+export function createVariableNameResolver(
+    variables: VariablesNameConfig | undefined
+): (path: string) => string {
+    const variableName = variables?.variableName;
+    if (variableName) return variableName;
+
+    const prefix = variables?.prefix;
+    if (prefix) return (path: string) => `${prefix}-${formatCSSVarName(path)}`;
+
+    return formatCSSVarName;
 }

--- a/packages/core/src/shared/resolve-variable-name.ts
+++ b/packages/core/src/shared/resolve-variable-name.ts
@@ -1,0 +1,18 @@
+import type { InternalConfig } from "../types/config.js";
+import { formatCSSVarName } from "./format-css-var-name.js";
+
+/**
+ * Resolve the CSS variable name for a token path, honouring the user's
+ * `variables.prefix` config. Called once per token during the pipeline
+ * and stored on `token.$names.css` — every emission site (declarations,
+ * references, utility classes) reads that cached name.
+ *
+ * This function is the single source of truth for CSS variable naming.
+ * Extend it here to change how names are produced; callers do not need
+ * to know about the rules.
+ */
+export function resolveVariableName(path: string, config: InternalConfig): string {
+    const base = formatCSSVarName(path);
+    const { prefix } = config.variables;
+    return prefix ? `${prefix}-${base}` : base;
+}

--- a/packages/core/src/shared/schemas/config.ts
+++ b/packages/core/src/shared/schemas/config.ts
@@ -38,9 +38,17 @@ const transformsSchema = z.object({
     colorFallbackStrategy: z.enum(["native", "polyfill"]).optional(),
 });
 
+// Zod's built-in z.function() wraps the callback with runtime arg validation,
+// which would break reference identity — users pass their own function in and
+// expect the same function back. We just verify it's callable and pass through.
+const variableNameFnSchema = z.custom<(path: string) => string>((v) => typeof v === "function", {
+    message: "variableName must be a function",
+});
+
 const variablesConfigSchema = z.object({
     path: z.string().optional(),
     prefix: z.string().optional(),
+    variableName: variableNameFnSchema.optional(),
     layer: z.string().optional(),
     transforms: transformsSchema.optional(),
     permutations: z.array(permutationSchema).optional(),
@@ -144,6 +152,7 @@ export const internalConfigSchema = z.object({
     variables: z.object({
         path: z.string(),
         prefix: z.string().optional(),
+        variableName: variableNameFnSchema.optional(),
         layer: z.string().optional(),
         transforms: z.object({
             fluid: fluidSchema,

--- a/packages/core/src/shared/schemas/config.ts
+++ b/packages/core/src/shared/schemas/config.ts
@@ -40,6 +40,7 @@ const transformsSchema = z.object({
 
 const variablesConfigSchema = z.object({
     path: z.string().optional(),
+    prefix: z.string().optional(),
     layer: z.string().optional(),
     transforms: transformsSchema.optional(),
     permutations: z.array(permutationSchema).optional(),
@@ -142,6 +143,7 @@ export const internalConfigSchema = z.object({
 
     variables: z.object({
         path: z.string(),
+        prefix: z.string().optional(),
         layer: z.string().optional(),
         transforms: z.object({
             fluid: fluidSchema,

--- a/packages/core/src/shared/uno-rules.ts
+++ b/packages/core/src/shared/uno-rules.ts
@@ -7,7 +7,6 @@ import { ErrorMessages } from "./constants/error-messages.js";
 
 type CSSObject = Record<string, string | number | undefined>;
 
-const CSS_VAR_PREFIX = "--";
 const DIRECTION_SEPARATOR = "-";
 const EXCLUDED_DIRECTIONS = ["all", "full"] as const;
 const DIRECTION_ABBREVIATIONS: Record<DirectionalVariant, string> = {
@@ -92,8 +91,8 @@ const pathIndexCache = new WeakMap<
 >();
 
 // Cache for findMatchingToken results to avoid repeated lookups for the same class
-// Key format: `${source}:${tokenName}` → token path or null
-const matchCache = new Map<string, string[] | null>();
+// Key format: `${source}:${tokenName}` → matched token or null
+const matchCache = new Map<string, ConvertedToken | null>();
 
 /**
  * Clears the token matching cache.
@@ -150,7 +149,7 @@ export function findMatchingToken(
     tokenName: string,
     config: PropertyUtilityConfig & { property?: string },
     tokens: NormalizedConvertedTokens
-): string[] | null {
+): ConvertedToken | null {
     const cacheKey = `${config.source}:${config.prefix ?? ""}:${config.property ?? ""}:${tokenName}`;
     if (matchCache.has(cacheKey)) {
         return matchCache.get(cacheKey) ?? null;
@@ -199,9 +198,8 @@ export function findMatchingToken(
                 }
             }
 
-            const result = token.$path.split(".");
-            matchCache.set(cacheKey, result);
-            return result;
+            matchCache.set(cacheKey, token);
+            return token;
         }
     }
 
@@ -241,9 +239,9 @@ function createSimpleRule(
 
             const processedTokenName = stripDuplicatePrefix(tokenName, config);
             const configWithProperty = { ...config, property };
-            const tokenPath = findMatchingToken(processedTokenName, configWithProperty, tokens);
-            if (!tokenPath) return {};
-            return { [property]: `var(${CSS_VAR_PREFIX}${tokenPath.join(DIRECTION_SEPARATOR)})` };
+            const matched = findMatchingToken(processedTokenName, configWithProperty, tokens);
+            if (!matched) return {};
+            return { [property]: `var(--${matched.$names.css})` };
         },
     ];
 }
@@ -269,11 +267,11 @@ function createDirectionalRule(
 
             const processedTokenName = stripDuplicatePrefix(tokenName, config);
             const configWithProperty = { ...config, property };
-            const tokenPath = findMatchingToken(processedTokenName, configWithProperty, tokens);
-            if (!tokenPath) return {};
+            const matched = findMatchingToken(processedTokenName, configWithProperty, tokens);
+            if (!matched) return {};
             const logicalProperty = getLogicalProperty(property, direction);
             return {
-                [logicalProperty]: `var(${CSS_VAR_PREFIX}${tokenPath.join(DIRECTION_SEPARATOR)})`,
+                [logicalProperty]: `var(--${matched.$names.css})`,
             };
         },
     ];
@@ -301,16 +299,16 @@ function createSmartRule(
             for (const { property, config, direction, tokens } of rulesForPrefix) {
                 const processedTokenName = stripDuplicatePrefix(tokenName, config);
                 const configWithProperty = { ...config, property };
-                const tokenPath = findMatchingToken(processedTokenName, configWithProperty, tokens);
-                if (tokenPath) {
+                const matched = findMatchingToken(processedTokenName, configWithProperty, tokens);
+                if (matched) {
                     if (direction) {
                         const logicalProperty = getLogicalProperty(property, direction);
                         return {
-                            [logicalProperty]: `var(${CSS_VAR_PREFIX}${tokenPath.join(DIRECTION_SEPARATOR)})`,
+                            [logicalProperty]: `var(--${matched.$names.css})`,
                         };
                     }
                     return {
-                        [property]: `var(${CSS_VAR_PREFIX}${tokenPath.join(DIRECTION_SEPARATOR)})`,
+                        [property]: `var(--${matched.$names.css})`,
                     };
                 }
             }
@@ -337,9 +335,9 @@ function createDirectTokenPathRule(
             const tokenName = match[1];
             if (!tokenName) return {};
             const configWithProperty = { ...config, property };
-            const tokenPath = findMatchingToken(tokenName, configWithProperty, tokens);
-            if (!tokenPath) return {};
-            return { [property]: `var(${CSS_VAR_PREFIX}${tokenPath.join(DIRECTION_SEPARATOR)})` };
+            const matched = findMatchingToken(tokenName, configWithProperty, tokens);
+            if (!matched) return {};
+            return { [property]: `var(--${matched.$names.css})` };
         },
     ];
 }

--- a/packages/core/src/shared/uno-rules.ts
+++ b/packages/core/src/shared/uno-rules.ts
@@ -92,6 +92,10 @@ const pathIndexCache = new WeakMap<
 
 // Cache for findMatchingToken results to avoid repeated lookups for the same class
 // Key format: `${source}:${tokenName}` → matched token or null
+// TODO: key on tokens identity (WeakMap) like pathIndexCache above — current
+// cache collides across tokens objects with the same (source, prefix, name)
+// key, which can return stale $names.css when configs differ. Harmless in a
+// single-build production path; manifests in tests and multi-instance use.
 const matchCache = new Map<string, ConvertedToken | null>();
 
 /**

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -3,6 +3,20 @@ import type { PropertyUtilityConfig } from "./utilities.js";
 export type ColorFallbackStrategy = "native" | "polyfill";
 
 /**
+ * Callback that maps a token's DTCG path to its final CSS variable name
+ * (without the leading `--`). Escape hatch for users who need full control —
+ * overrides `variables.prefix` entirely when set.
+ *
+ * @param path - The DTCG path of the token (e.g. `"color.brandPrimary"`).
+ * @returns The CSS variable name without the leading `--`.
+ *
+ * @example
+ * // Style-Dictionary-compatible kebab-case with prefix
+ * variableName: (path) => `ds-${path.replaceAll(".", "-").toLowerCase()}`
+ */
+export type VariableNameFn = (path: string) => string;
+
+/**
  * A permutation defines a single resolved token set and how to output it as CSS.
  * Each permutation specifies a resolver input (which modifier contexts to use)
  * and a CSS selector to wrap the output in.
@@ -66,6 +80,18 @@ export interface VariablesConfig {
      * // color.brandPrimary → --ds-color-brandPrimary
      */
     prefix?: string;
+
+    /**
+     * Full-control callback for computing the CSS variable name from a
+     * token path. Overrides `prefix` entirely when set — the user owns
+     * both prefixing and case-handling.
+     *
+     * Returns the name *without* the leading `--`.
+     *
+     * @example
+     * variableName: (path) => `ds-${path.replaceAll(".", "-").toLowerCase()}`
+     */
+    variableName?: VariableNameFn;
 
     /**
      * CSS cascade layer name for variables.
@@ -445,6 +471,7 @@ export interface InternalConfig {
     variables: {
         path: string;
         prefix?: string;
+        variableName?: VariableNameFn;
         layer?: string;
         transforms: {
             fluid: FluidConfig;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -59,6 +59,15 @@ export interface VariablesConfig {
     path?: string;
 
     /**
+     * Prefix prepended to every generated CSS variable name.
+     *
+     * @example
+     * // prefix: "ds"
+     * // color.brandPrimary → --ds-color-brandPrimary
+     */
+    prefix?: string;
+
+    /**
      * CSS cascade layer name for variables.
      * When set, output is wrapped in @layer block.
      * @example "tokens"
@@ -435,6 +444,7 @@ export interface InternalConfig {
     /** CSS variables output configuration */
     variables: {
         path: string;
+        prefix?: string;
         layer?: string;
         transforms: {
             fluid: FluidConfig;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -11,7 +11,7 @@ export type ColorFallbackStrategy = "native" | "polyfill";
  * @returns The CSS variable name without the leading `--`.
  *
  * @example
- * // Style-Dictionary-compatible kebab-case with prefix
+ * // Kebab-case everything, with a prefix
  * variableName: (path) => `ds-${path.replaceAll(".", "-").toLowerCase()}`
  */
 export type VariableNameFn = (path: string) => string;

--- a/packages/core/src/types/convert.ts
+++ b/packages/core/src/types/convert.ts
@@ -24,8 +24,20 @@ export type TokenConverter<T extends TokenType> = (
     options: ConversionOptions
 ) => CSSProperties<T>;
 
+/**
+ * Per-format output names for a token. Today CSS is the only format populated;
+ * future formats (js, scss, …) will add their own keys.
+ *
+ * Computed once during the pipeline and read by every emission site so
+ * declarations, references, and utility classes cannot drift apart.
+ */
+export type TokenNames = {
+    css: string;
+};
+
 export type ConvertedToken<T extends TokenType = TokenType> = ResolvedToken<T> & {
     $cssProperties: CSSProperties<T>;
+    $names: TokenNames;
 };
 
 export type ConvertedTokens = {

--- a/packages/core/tests/__fixtures__/converted-tokens.ts
+++ b/packages/core/tests/__fixtures__/converted-tokens.ts
@@ -1,18 +1,25 @@
+import { formatCSSVarName } from "../../src/shared/format-css-var-name.js";
 import type { ConvertedToken } from "../../src/types/convert.js";
 import type { TokenType } from "../../src/types/tokens.js";
 
 export const createConvertedToken = (
     overrides: Partial<ConvertedToken<TokenType>> = {}
-): ConvertedToken<TokenType> => ({
-    $type: "color" as const,
-    $value: "#FF0000",
-    $path: "color.primary",
-    $source: { sourcePath: "test.json" },
-    $originalPath: "color.primary",
-    $resolvedValue: "#FF0000",
-    $cssProperties: { value: "#FF0000" },
-    ...overrides,
-});
+): ConvertedToken<TokenType> => {
+    const base = {
+        $type: "color" as const,
+        $value: "#FF0000",
+        $path: "color.primary",
+        $source: { sourcePath: "test.json" },
+        $originalPath: "color.primary",
+        $resolvedValue: "#FF0000",
+        $cssProperties: { value: "#FF0000" },
+        ...overrides,
+    };
+    return {
+        ...base,
+        $names: overrides.$names ?? { css: formatCSSVarName(base.$path) },
+    };
+};
 
 export const convertedTokens = {
     colorPrimary: createConvertedToken(),

--- a/packages/core/tests/convert-utility-config-to-uno-rules.test.ts
+++ b/packages/core/tests/convert-utility-config-to-uno-rules.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+    clearMatchCache,
     convertConfigToUnoRules,
     findMatchingToken,
     getDirectionAbbreviation,
@@ -53,6 +54,27 @@ describe("convertConfigToUnoRules", () => {
             testRule(rules, "text-primary", { color: "var(--color-primary)" });
             testRule(rules, "text-secondary", { color: "var(--color-secondary)" });
             testRule(rules, "bg-primary", null);
+        });
+
+        it("emits prefixed var() when tokens carry a prefixed $names.css", () => {
+            // Match cache is keyed on config+tokenName, not token identity —
+            // clear it so this test doesn't see the unprefixed token cached
+            // by the previous test using the same (source, prefix, name) key.
+            clearMatchCache();
+
+            const prefixedTokens = buildTokens({
+                "color-primary": createConvertedToken({
+                    $path: "color.primary",
+                    $names: { css: "ds-color-primary" },
+                }),
+            });
+
+            const rules = convertConfigToUnoRules(
+                { color: { source: "color.*", prefix: "text" } },
+                prefixedTokens
+            );
+
+            testRule(rules, "text-primary", { color: "var(--ds-color-primary)" });
         });
 
         it("uses source path base as prefix when no prefix specified", () => {

--- a/packages/core/tests/convert-utility-config-to-uno-rules.test.ts
+++ b/packages/core/tests/convert-utility-config-to-uno-rules.test.ts
@@ -213,14 +213,13 @@ describe("findMatchingToken", () => {
     });
 
     it("finds token by matching source pattern", () => {
-        expect(findMatchingToken("primary", { source: "color.*", prefix: "text" }, tokens)).toEqual(
-            ["color", "primary"]
-        );
+        expect(
+            findMatchingToken("primary", { source: "color.*", prefix: "text" }, tokens)?.$path
+        ).toBe("color.primary");
 
-        expect(findMatchingToken("small", { source: "spacing.*", prefix: "p" }, tokens)).toEqual([
-            "spacing",
-            "small",
-        ]);
+        expect(
+            findMatchingToken("small", { source: "spacing.*", prefix: "p" }, tokens)?.$path
+        ).toBe("spacing.small");
     });
 
     it("returns null when no token matches", () => {

--- a/packages/core/tests/convert.test.ts
+++ b/packages/core/tests/convert.test.ts
@@ -117,4 +117,45 @@ describe("convert", () => {
         const token = result.default?.["color.primary"] as ConvertedToken<TokenType>;
         expect(token.$names.css).toBe("ds-color-primary");
     });
+
+    it("uses variables.variableName callback when set", () => {
+        const tokens: NormalizedTokens = {
+            default: {
+                "color.primary": createResolvedToken(),
+            },
+        };
+
+        const result = applyConverters(
+            tokens,
+            fillDefaults({
+                variables: {
+                    variableName: (path) => `custom--${path.replaceAll(".", "_")}`,
+                },
+            })
+        );
+
+        const token = result.default?.["color.primary"] as ConvertedToken<TokenType>;
+        expect(token.$names.css).toBe("custom--color_primary");
+    });
+
+    it("variableName overrides prefix when both are set", () => {
+        const tokens: NormalizedTokens = {
+            default: {
+                "color.primary": createResolvedToken(),
+            },
+        };
+
+        const result = applyConverters(
+            tokens,
+            fillDefaults({
+                variables: {
+                    prefix: "ignored",
+                    variableName: (path) => `only-${path.replaceAll(".", "-")}`,
+                },
+            })
+        );
+
+        const token = result.default?.["color.primary"] as ConvertedToken<TokenType>;
+        expect(token.$names.css).toBe("only-color-primary");
+    });
 });

--- a/packages/core/tests/convert.test.ts
+++ b/packages/core/tests/convert.test.ts
@@ -91,4 +91,30 @@ describe("convert", () => {
         expect(token.$cssProperties).toBeDefined();
         // We don't test the exact CSS properties here as that's covered by the individual converter tests
     });
+
+    it("populates $names.css from the token path", () => {
+        const tokens: NormalizedTokens = {
+            default: {
+                "color.primary": createResolvedToken(),
+            },
+        };
+
+        const result = applyConverters(tokens, fillDefaults(configs.basic));
+
+        const token = result.default?.["color.primary"] as ConvertedToken<TokenType>;
+        expect(token.$names.css).toBe("color-primary");
+    });
+
+    it("applies the variables.prefix config to $names.css", () => {
+        const tokens: NormalizedTokens = {
+            default: {
+                "color.primary": createResolvedToken(),
+            },
+        };
+
+        const result = applyConverters(tokens, fillDefaults({ variables: { prefix: "ds" } }));
+
+        const token = result.default?.["color.primary"] as ConvertedToken<TokenType>;
+        expect(token.$names.css).toBe("ds-color-primary");
+    });
 });

--- a/packages/core/tests/generate.test.ts
+++ b/packages/core/tests/generate.test.ts
@@ -268,6 +268,49 @@ describe("generate", () => {
         });
     });
 
+    describe("prefix", () => {
+        it("emits the prefixed name in declarations, references, and typography sub-vars", async () => {
+            const tokens: NormalizedConvertedTokens = {
+                "perm:0": {
+                    "color.primary": createConvertedToken({
+                        $path: "color.primary",
+                        $names: { css: "ds-color-primary" },
+                    }),
+                    "color.button": createConvertedToken({
+                        $path: "color.button",
+                        $value: "{color.primary}",
+                        $cssProperties: { value: "{color.primary}" },
+                        $names: { css: "ds-color-button" },
+                    }),
+                    "typography.body": createConvertedToken({
+                        $type: "typography",
+                        $path: "typography.body",
+                        $value: {
+                            fontFamily: "Arial",
+                            fontSize: "16px",
+                            lineHeight: 1.5,
+                            fontWeight: 400,
+                        },
+                        $cssProperties: {
+                            "font-family": "Arial",
+                            "font-size": "16px",
+                            "line-height": 1.5,
+                            "font-weight": 400,
+                        },
+                        $names: { css: "ds-typography-body" },
+                    }),
+                },
+            };
+
+            const config = configWith("basic", [{ input: {}, selector: ":root" }]);
+            const css = (await formatCSSVariables(tokens, config)).output[0]?.css ?? "";
+
+            expect(css).toContain("--ds-color-primary: #FF0000;");
+            expect(css).toContain("--ds-color-button: var(--ds-color-primary);");
+            expect(css).toContain("--ds-typography-body-font-family: Arial;");
+        });
+    });
+
     describe("path case preservation", () => {
         // Declarations and references must use the same var name even when
         // path segments contain camelCase characters. Pre-$names, declarations

--- a/packages/core/tests/generate.test.ts
+++ b/packages/core/tests/generate.test.ts
@@ -342,67 +342,69 @@ describe("generate", () => {
         });
     });
 
-    // DTCG 2025.10 §6.2: a $root token represents the group's base value.
-    // Its CSS variable should be the group's path — "$root" is a reference-only
-    // disambiguator and must not appear in emitted identifiers.
-    it("emits $root tokens using the group path without a $root segment", async () => {
-        const tokens: NormalizedConvertedTokens = {
-            "perm:0": {
-                "blue.$root": createConvertedToken({
-                    $value: "#0000FF",
-                    $path: "blue.$root",
-                    $originalPath: "blue.$root",
-                    $resolvedValue: "#0000FF",
-                    $cssProperties: { value: "#0000FF" },
-                }),
-                "blue.50": createConvertedToken({
-                    $value: "#ADD8E6",
-                    $path: "blue.50",
-                    $originalPath: "blue.50",
-                    $resolvedValue: "#ADD8E6",
-                    $cssProperties: { value: "#ADD8E6" },
-                }),
-            },
-        };
+    describe("$root tokens", () => {
+        // DTCG 2025.10 §6.2: a $root token represents the group's base value.
+        // Its CSS variable should be the group's path — "$root" is a reference-only
+        // disambiguator and must not appear in emitted identifiers.
+        it("emits $root tokens using the group path without a $root segment", async () => {
+            const tokens: NormalizedConvertedTokens = {
+                "perm:0": {
+                    "blue.$root": createConvertedToken({
+                        $value: "#0000FF",
+                        $path: "blue.$root",
+                        $originalPath: "blue.$root",
+                        $resolvedValue: "#0000FF",
+                        $cssProperties: { value: "#0000FF" },
+                    }),
+                    "blue.50": createConvertedToken({
+                        $value: "#ADD8E6",
+                        $path: "blue.50",
+                        $originalPath: "blue.50",
+                        $resolvedValue: "#ADD8E6",
+                        $cssProperties: { value: "#ADD8E6" },
+                    }),
+                },
+            };
 
-        const config = configWith("basic", [{ input: {}, selector: ":root" }]);
+            const config = configWith("basic", [{ input: {}, selector: ":root" }]);
 
-        const result = await formatCSSVariables(tokens, config);
-        const css = result.output[0]?.css ?? "";
+            const result = await formatCSSVariables(tokens, config);
+            const css = result.output[0]?.css ?? "";
 
-        expect(css).toContain("--blue: #0000FF;");
-        expect(css).toContain("--blue-50: #ADD8E6;");
-        expect(css).not.toContain("$root");
-    });
+            expect(css).toContain("--blue: #0000FF;");
+            expect(css).toContain("--blue-50: #ADD8E6;");
+            expect(css).not.toContain("$root");
+        });
 
-    // References to a $root token (e.g. {blue.$root}) must emit the group's
-    // CSS variable — var(--blue) — not var(--blue-$root).
-    it("emits var(--…) references to $root tokens using the group path", async () => {
-        const tokens: NormalizedConvertedTokens = {
-            "perm:0": {
-                "blue.$root": createConvertedToken({
-                    $value: "#0000FF",
-                    $path: "blue.$root",
-                    $originalPath: "blue.$root",
-                    $resolvedValue: "#0000FF",
-                    $cssProperties: { value: "#0000FF" },
-                }),
-                "border.primary": createConvertedToken({
-                    $value: "{blue.$root}",
-                    $path: "border.primary",
-                    $originalPath: "border.primary",
-                    $resolvedValue: "#0000FF",
-                    $cssProperties: { value: "{blue.$root}" },
-                }),
-            },
-        };
+        // References to a $root token (e.g. {blue.$root}) must emit the group's
+        // CSS variable — var(--blue) — not var(--blue-$root).
+        it("emits var(--…) references to $root tokens using the group path", async () => {
+            const tokens: NormalizedConvertedTokens = {
+                "perm:0": {
+                    "blue.$root": createConvertedToken({
+                        $value: "#0000FF",
+                        $path: "blue.$root",
+                        $originalPath: "blue.$root",
+                        $resolvedValue: "#0000FF",
+                        $cssProperties: { value: "#0000FF" },
+                    }),
+                    "border.primary": createConvertedToken({
+                        $value: "{blue.$root}",
+                        $path: "border.primary",
+                        $originalPath: "border.primary",
+                        $resolvedValue: "#0000FF",
+                        $cssProperties: { value: "{blue.$root}" },
+                    }),
+                },
+            };
 
-        const config = configWith("basic", [{ input: {}, selector: ":root" }]);
+            const config = configWith("basic", [{ input: {}, selector: ":root" }]);
 
-        const result = await formatCSSVariables(tokens, config);
-        const css = result.output[0]?.css ?? "";
+            const result = await formatCSSVariables(tokens, config);
+            const css = result.output[0]?.css ?? "";
 
-        expect(css).toContain("--border-primary: var(--blue);");
-        expect(css).not.toContain("$root");
+            expect(css).toContain("--border-primary: var(--blue);");
+            expect(css).not.toContain("$root");
+        });
     });
 });

--- a/packages/core/tests/generate.test.ts
+++ b/packages/core/tests/generate.test.ts
@@ -268,6 +268,37 @@ describe("generate", () => {
         });
     });
 
+    describe("path case preservation", () => {
+        // Declarations and references must use the same var name even when
+        // path segments contain camelCase characters. Pre-$names, declarations
+        // preserved case (--color-brandPrimary) while references kebab-cased
+        // (var(--color-brand-primary)) — producing a dangling reference.
+        it("keeps declaration and reference names in sync for camelCase paths", async () => {
+            const tokens: NormalizedConvertedTokens = {
+                "perm:0": {
+                    "color.brandPrimary": createConvertedToken({
+                        $path: "color.brandPrimary",
+                        $value: "#FF0000",
+                        $resolvedValue: "#FF0000",
+                        $cssProperties: { value: "#FF0000" },
+                    }),
+                    "color.button": createConvertedToken({
+                        $path: "color.button",
+                        $value: "{color.brandPrimary}",
+                        $resolvedValue: "#FF0000",
+                        $cssProperties: { value: "{color.brandPrimary}" },
+                    }),
+                },
+            };
+
+            const config = configWith("basic", [{ input: {}, selector: ":root" }]);
+            const css = (await formatCSSVariables(tokens, config)).output[0]?.css ?? "";
+
+            expect(css).toContain("--color-brandPrimary: #FF0000;");
+            expect(css).toContain("--color-button: var(--color-brandPrimary);");
+        });
+    });
+
     // DTCG 2025.10 §6.2: a $root token represents the group's base value.
     // Its CSS variable should be the group's path — "$root" is a reference-only
     // disambiguator and must not appear in emitted identifiers.

--- a/packages/core/tests/normalize-config.test.ts
+++ b/packages/core/tests/normalize-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { validateConfig } from "../src/node/config/normalize.js";
 import { fillDefaults } from "../src/node/config/normalize.js";
 import { DEFAULT_CONFIG } from "../src/shared/constants/config.js";
 import type { SugarcubeConfig } from "../src/types/config.js";
@@ -158,5 +159,43 @@ describe("fillDefaults", () => {
 
             expect(result.components).toBe("lib/ui");
         });
+    });
+});
+
+describe("validateConfig — variables.variableName", () => {
+    it("accepts a function and preserves reference identity", () => {
+        const userFn = (path: string) => `custom-${path}`;
+        const result = validateConfig({
+            resolver: "./tokens.resolver.json",
+            variables: { variableName: userFn },
+        });
+
+        // Reference identity matters — z.function() wraps and would break this.
+        expect(result.variables.variableName).toBe(userFn);
+        expect(result.variables.variableName?.("color.primary")).toBe("custom-color.primary");
+    });
+
+    it("leaves variableName undefined when omitted", () => {
+        const result = validateConfig({
+            resolver: "./tokens.resolver.json",
+        });
+
+        expect(result.variables.variableName).toBeUndefined();
+    });
+
+    it.each([
+        ["string", "not a function"],
+        ["number", 42],
+        ["object", {}],
+        ["array", [1, 2, 3]],
+        ["null", null],
+    ])("rejects %s", (_label, value) => {
+        expect(() =>
+            validateConfig({
+                resolver: "./tokens.resolver.json",
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                variables: { variableName: value as any },
+            })
+        ).toThrow(/variableName must be a function/);
     });
 });

--- a/packages/studio/src/controls/ColorTokenControl.tsx
+++ b/packages/studio/src/controls/ColorTokenControl.tsx
@@ -1,12 +1,13 @@
-import {
-    type ColorBinding,
-    type ColorScaleConfig,
-    type ResolvedTokens,
-    formatCSSVarName,
-} from "@sugarcube-sh/core/client";
+import type { ColorBinding, ColorScaleConfig, ResolvedTokens } from "@sugarcube-sh/core/client";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popover/popover";
-import { useCurrentContext, usePathIndex, useToken, useTokenStore } from "../store/hooks";
+import {
+    useCurrentContext,
+    usePathIndex,
+    useToken,
+    useTokenStore,
+    useVariableName,
+} from "../store/hooks";
 import type { PathIndex } from "../tokens/path-index";
 import { TokenRow } from "./TokenRow";
 import { joinTokenPath, unwrapRef, wrapRef } from "./path-utils";
@@ -35,11 +36,15 @@ export function ColorTokenControl({ binding, colorScale }: ColorTokenControlProp
     const pathIndex = usePathIndex();
     const resolved = useTokenStore((state) => state.resolved);
     const currentContext = useCurrentContext();
+    const variableName = useVariableName();
     const label = labelForBinding(binding);
     const [open, setOpen] = useState(false);
     const popoverRef = useRef<HTMLDivElement>(null);
 
-    const { columns, rows, cells, byPath } = useMemo(() => buildGrid(colorScale), [colorScale]);
+    const { columns, rows, cells, byPath } = useMemo(
+        () => buildGrid(colorScale, variableName),
+        [colorScale, variableName]
+    );
 
     const terminalPath = resolveRefChain(value, pathIndex, resolved, currentContext) ?? "";
     const currentOption = byPath.get(terminalPath);
@@ -95,7 +100,10 @@ type BuiltGrid = {
     byPath: Map<string, GridOption>;
 };
 
-function buildGrid(colorScale: ColorScaleConfig): BuiltGrid {
+function buildGrid(
+    colorScale: ColorScaleConfig,
+    variableName: (path: string) => string
+): BuiltGrid {
     const { prefix, palettes, steps, white, black } = colorScale;
     const hasExtras = Boolean(white || black);
     const columns = hasExtras ? [...palettes, ""] : [...palettes];
@@ -107,7 +115,7 @@ function buildGrid(colorScale: ColorScaleConfig): BuiltGrid {
             const path = joinTokenPath(prefix, palette, step);
             const option: GridOption = {
                 path,
-                color: `var(--${formatCSSVarName(path)})`,
+                color: `var(--${variableName(path)})`,
                 label: `${palette} ${step}`,
             };
             byPath.set(path, option);
@@ -122,7 +130,7 @@ function buildGrid(colorScale: ColorScaleConfig): BuiltGrid {
                 const label = extraToken.split(".").pop() ?? extraToken;
                 const option: GridOption = {
                     path: extraToken,
-                    color: `var(--${formatCSSVarName(extraToken)})`,
+                    color: `var(--${variableName(extraToken)})`,
                     label,
                 };
                 byPath.set(extraToken, option);

--- a/packages/studio/src/controls/PaletteSwapControl.tsx
+++ b/packages/studio/src/controls/PaletteSwapControl.tsx
@@ -1,6 +1,12 @@
-import { type ColorScaleConfig, formatCSSVarName } from "@sugarcube-sh/core/client";
+import type { ColorScaleConfig } from "@sugarcube-sh/core/client";
 import { useCallback, useContext, useMemo } from "react";
-import { StudioContext, useFamilyPalette, usePathIndex, useTokenStore } from "../store/hooks";
+import {
+    StudioContext,
+    useFamilyPalette,
+    usePathIndex,
+    useTokenStore,
+    useVariableName,
+} from "../store/hooks";
 import { familyPaletteSwapUpdates } from "../tokens/palette-cascade";
 import { TokenRow } from "./TokenRow";
 import { joinTokenPath } from "./path-utils";
@@ -33,9 +39,13 @@ export function PaletteSwapControl({
     const ctx = useContext(StudioContext);
     const pathIndex = usePathIndex();
     const setTokens = useTokenStore((state) => state.setTokens);
+    const variableName = useVariableName();
     const current = useFamilyPalette(family, palettes) ?? palettes[0] ?? "";
 
-    const options = useMemo(() => buildOptions(palettes, colorScale), [palettes, colorScale]);
+    const options = useMemo(
+        () => buildOptions(palettes, colorScale, variableName),
+        [palettes, colorScale, variableName]
+    );
 
     const handleChange = useCallback(
         (newPalette: string) => {
@@ -55,12 +65,16 @@ export function PaletteSwapControl({
     );
 }
 
-function buildOptions(palettes: readonly string[], colorScale: ColorScaleConfig): PaletteOption[] {
+function buildOptions(
+    palettes: readonly string[],
+    colorScale: ColorScaleConfig,
+    variableName: (path: string) => string
+): PaletteOption[] {
     return palettes.map((palette) => ({
         name: palette,
         shades: colorScale.steps.map((step) => {
             const path = joinTokenPath(colorScale.prefix, palette, step);
-            return `var(--${formatCSSVarName(path)})`;
+            return `var(--${variableName(path)})`;
         }),
     }));
 }

--- a/packages/studio/src/store/hooks.ts
+++ b/packages/studio/src/store/hooks.ts
@@ -1,4 +1,4 @@
-import type { StudioConfig } from "@sugarcube-sh/core/client";
+import { type StudioConfig, createVariableNameResolver } from "@sugarcube-sh/core/client";
 import { createContext, useContext, useMemo } from "react";
 import { useStore } from "zustand";
 import { computeDiff } from "../tokens/compute-diff";
@@ -36,6 +36,11 @@ export function useStudioMode(): StudioContextValue["mode"] {
 /** The project's studio panel config. */
 export function useStudioConfig(): StudioConfig | undefined {
     return useStudio().studioConfig;
+}
+
+export function useVariableName(): (path: string) => string {
+    const { snapshot } = useStudio();
+    return useMemo(() => createVariableNameResolver(snapshot.config.variables), [snapshot]);
 }
 
 export function usePathIndex(): PathIndex {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -556,5 +556,5 @@ export default async function sugarcubePlugin(options: SugarcubePluginOptions = 
     return plugins;
 }
 
-export { defineConfig } from "@sugarcube-sh/core";
-export type { SugarcubeConfig };
+export { defineConfig, kebabCase } from "@sugarcube-sh/core";
+export type { SugarcubeConfig, VariableNameFn } from "@sugarcube-sh/core";


### PR DESCRIPTION
Closes #80.

Adds a `variables.prefix` config option (plus a `--prefix` CLI flag and a `variableName` callback for anyone who wants full control over naming). Computes CSS variable names once per token and has every emitter read from one place - which, incidentally, fixed a latent bug where tokens with camelCase paths were forced into kebab case.