### PR TITLE
fix: drop new Function workaround for Bun config loading

### DIFF
--- a/.changeset/mellow-forests-hum.md
+++ b/.changeset/mellow-forests-hum.md
@@ -1,0 +1,5 @@
+---
+"@sugarcube-sh/core": patch
+---
+
+Preserve source token order in generated CSS output, so variables appear in the same order they're declared in your token files.

--- a/.changeset/quiet-rivers-bloom.md
+++ b/.changeset/quiet-rivers-bloom.md
@@ -1,0 +1,5 @@
+---
+"@sugarcube-sh/core": patch
+---
+
+Drop the `new Function` dynamic-import workaround in the Bun config-loading path. Jiti handles TypeScript configs natively in Bun now, so the extra branch isn't needed — and removing it clears the eval warning on socket.dev.

--- a/packages/core/src/node/config/load.ts
+++ b/packages/core/src/node/config/load.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
-import { pathToFileURL } from "node:url";
 import { createJiti } from "jiti";
 import { resolve } from "pathe";
 import { validateInternalConfig, validateSugarcubeConfig } from "../../shared/config.js";
@@ -49,28 +48,6 @@ export function configFileExists(basePath = "sugarcube.config"): boolean {
 
 async function loadTSConfig(configPath: string): Promise<unknown> {
     try {
-        // Check if we're running in Bun (which has native TypeScript support)
-        // Use globalThis to avoid TypeScript errors about Bun types
-        const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
-
-        if (isBun) {
-            // Bun has native TypeScript support
-            const fileUrl = pathToFileURL(configPath).href;
-            const dynamicImport = new Function("url", "return import(url)");
-            const result = await dynamicImport(fileUrl);
-
-            if (result && typeof result === "object" && "default" in result) {
-                return result.default;
-            }
-
-            throw new Error(
-                ErrorMessages.CONFIG.INVALID_CONFIG(
-                    "root",
-                    "Config file must export a default object"
-                )
-            );
-        }
-
         const jiti = createJiti(import.meta.url, {
             interopDefault: true,
             moduleCache: false,


### PR DESCRIPTION
Jiti seems to handle TS configs fine in Bun now, so the dynamic-import trick isn't needed. Also clears the eval warning on socket.dev.