### PR TITLE
feat: preserve token order in css gen

### DIFF
--- a/packages/core/src/node/resolver/find.ts
+++ b/packages/core/src/node/resolver/find.ts
@@ -15,6 +15,8 @@ export type ResolverDiscoveryResult =
  */
 export async function findResolverDocument(directory: string): Promise<ResolverDiscoveryResult> {
     const pattern = "**/*.resolver.json";
+    // tinyglobby returns files in filesystem-enumeration order, which varies cross-OS.
+    // Don't rely on this list being stably ordered. Sort explicitly if we need that.
     const files = await glob([pattern], {
         cwd: directory,
         onlyFiles: true,

--- a/packages/core/src/shared/pipeline/format-css-variables.ts
+++ b/packages/core/src/shared/pipeline/format-css-variables.ts
@@ -16,10 +16,6 @@ import { ErrorMessages } from "../constants/error-messages.js";
 import { formatCSSVarName } from "../format-css-var-name.js";
 import { isTypographyToken } from "../guards.js";
 
-function deterministicEntries<T>(obj: Record<string, T>): [string, T][] {
-    return Object.entries(obj).sort(([a], [b]) => a.localeCompare(b));
-}
-
 function indentCSS(css: string, spaces = 4): string {
     const indent = " ".repeat(spaces);
     return css
@@ -170,7 +166,9 @@ function generateVariablesFromTokens(tokens: ConvertedTokens): {
     features: CSSFeatureBlock[];
 } {
     const nameLookup = buildNameLookup(tokens);
-    const varSets = deterministicEntries(tokens)
+    // Iterate in insertion order so output mirrors the order tokens were authored
+    // in source DTCG files (and the order modifier expansions emit them).
+    const varSets = Object.entries(tokens)
         .filter(([key, token]) => key !== "$extensions" && "$type" in token)
         .map(([_, token]) =>
             generateVariablesForToken(token as ConvertedToken<TokenType>, nameLookup)

--- a/packages/core/tests/generate.test.ts
+++ b/packages/core/tests/generate.test.ts
@@ -407,4 +407,35 @@ describe("generate", () => {
             expect(css).not.toContain("$root");
         });
     });
+
+    describe("source order preservation", () => {
+        it("emits declarations in authored order, not alphabetical", async () => {
+            const sizes = ["xs", "sm", "md", "lg", "xl", "2xl", "3xl"];
+            const tokens: NormalizedConvertedTokens = {
+                "perm:0": Object.fromEntries(
+                    sizes.map((size) => [
+                        `radius.${size}`,
+                        createConvertedToken({
+                            $type: "dimension",
+                            $value: `${size}-value`,
+                            $path: `radius.${size}`,
+                            $originalPath: `radius.${size}`,
+                            $resolvedValue: `${size}-value`,
+                            $cssProperties: { value: `${size}-value` },
+                        }),
+                    ])
+                ),
+            };
+
+            const config = configWith("basic", [{ input: {}, selector: ":root" }]);
+            const result = await formatCSSVariables(tokens, config);
+            const css = result.output[0]?.css ?? "";
+
+            const indices = sizes.map((size) => css.indexOf(`--radius-${size}:`));
+            expect(indices.every((i) => i >= 0)).toBe(true);
+            for (let i = 1; i < indices.length; i++) {
+                expect(indices[i]).toBeGreaterThan(indices[i - 1] ?? -1);
+            }
+        });
+    });
 });


### PR DESCRIPTION
Closes #88.

Pre-resolver spec, css gen was alphabetical to avoid unwanted diffs.

Since the release of the resolver spec, our css gen logic underwent a rewrite. That rewrite makes preserving token order (rather than alphabetical order) much easier.