### PR TITLE
feat(core): scale API

### DIFF
--- a/.changeset/light-experts-hammer.md
+++ b/.changeset/light-experts-hammer.md
@@ -28,10 +28,7 @@ Two modes:
 
 Malformed recipes surface as `ExpandError`s; the group is left intact (without generated children) and the rest of the pipeline continues.
 
-**New exports (from `@sugarcube-sh/core` and `/client`):**
-
-- `calculateScale(config)` — pure function that returns the generated steps without going through the pipeline. Useful for previews / studio controls.
-- Types: `ScaleExtension`, `ExponentialScaleConfig`, `MultiplierScaleConfig`, `FluidExtension`, `SugarcubeExtensions`, `GeneratedStep`.
+**New exported types (from `@sugarcube-sh/core` and `/client`):** `ScaleExtension`, `ExponentialScaleConfig`, `MultiplierScaleConfig`, `FluidExtension`, `SugarcubeExtensions`.
 
 **`ScaleBinding` semantics clarified.** A scale binding now dispatches purely on whether a recipe is authored at the bound path:
 

--- a/.changeset/light-experts-hammer.md
+++ b/.changeset/light-experts-hammer.md
@@ -1,0 +1,39 @@
+---
+"@sugarcube-sh/core": patch
+---
+
+**New: scale recipes.** Generate a family of fluid dimension tokens from a single group node by authoring a recipe under `$extensions["sh.sugarcube"].scale`. Sugarcube generates (virtually) the children during the expand pass, and each generated token carries a `sh.sugarcube.fluid` extension so the existing fluid renderer emits `clamp()` — virtual scale tokens are indistinguishable from hand-authored fluid tokens by the time they hit CSS.
+
+At present, no actual tokens are written to disk or outputted.
+
+Two modes:
+
+- **`exponential`**: base min/max + a min/max ratio + step counts. Generates symmetric steps around the base (e.g. `-2, -1, 0, 1, 2`).
+- **`multipliers`**: base min/max + a `Record<string, number>` of named multipliers. Optionally generates space pairs (`"adjacent"` for `sm-md`, `md-lg`, …, or an explicit list like `["sm-lg", "xs-xl"]`).
+
+```ts
+{
+  $extensions: {
+    "sh.sugarcube": {
+      scale: {
+        mode: "exponential",
+        base: { min: { value: 1, unit: "rem" }, max: { value: 1.125, unit: "rem" } },
+        ratio: { min: 1.2, max: 1.25 },
+        steps: { negative: 2, positive: 5 },
+      },
+    },
+  },
+}
+```
+
+Malformed recipes surface as `ExpandError`s; the group is left intact (without generated children) and the rest of the pipeline continues.
+
+**New exports (from `@sugarcube-sh/core` and `/client`):**
+
+- `calculateScale(config)` — pure function that returns the generated steps without going through the pipeline. Useful for previews / studio controls.
+- Types: `ScaleExtension`, `ExponentialScaleConfig`, `MultiplierScaleConfig`, `FluidExtension`, `SugarcubeExtensions`, `GeneratedStep`.
+
+**`ScaleBinding` semantics clarified.** A scale binding now dispatches purely on whether a recipe is authored at the bound path:
+
+- Recipe present -> recipe-aware controls; the recipe's `mode` field tells consumers whether to render exponential or multipliers UI.
+- No recipe -> bulk controls (base + spread) plus per-step inputs for direct editing of the concrete tokens.

--- a/apps/www/src/content/docs/docs/fluid-space-and-type.mdx
+++ b/apps/www/src/content/docs/docs/fluid-space-and-type.mdx
@@ -98,6 +98,12 @@ Sugarcube can generate scales for you from a single block of configuration autho
 
 The scale config goes under `$extensions["sh.sugarcube"].scale` on the group where you want the generated tokens to live. Sugarcube produces them at build time; once they reach the renderer they're indistinguishable from fluid tokens you've authored yourself.
 
+<SiteAside type="note">
+    Scale recipes intentionally don't generate token files on disk. The recipe is the source of truth. Keeping it that way avoids the problem of mixing generated and hand-authored tokens.
+
+    The tradeoff is interoperability: other DTCG tools see a group with an unknown `$extensions` block and produce nothing for it, since the children only exist once sugarcube generates them in-memory. If you need the generated tokens to land somewhere other tools can read, hand-author them using the `fluid` extension (covered above) instead.
+</SiteAside>
+
 Two modes are available: **exponential** for ratio-based scales (typically typography) and **multipliers** for arbitrary-step scales (typically spacing).
 
 ### Exponential mode

--- a/apps/www/src/content/docs/docs/fluid-space-and-type.mdx
+++ b/apps/www/src/content/docs/docs/fluid-space-and-type.mdx
@@ -3,6 +3,7 @@ title: Fluid Space & Type
 ---
 
 import SiteAside from "@/src/components/site-alert/SiteAside.astro";
+import Table from "@/src/components/Table.astro";
 
 Fluid spacing and typography create responsive designs that adapt naturally to different screen sizes. Sugarcube supports fluid dimensions using the standard DTCG `dimension` type with an extension.
 
@@ -88,6 +89,111 @@ export default defineConfig({
   }
 });
 ```
+
+## Generating a scale
+
+If you've ever iterated on a type or spacing scale, you know the loop: open [Utopia.fyi](https://utopia.fyi/), tweak the parameters, copy the generated values into your tokens, save, decide you don't like the rhythm, repeat. It works, but you end up spending more time bouncing between tools than thinking about the scale itself.
+
+Sugarcube can generate scales for you from a single block of configuration authored alongside your tokens. The feature is heavily inspired by Utopia but keeps everything in one place - iterating means editing one config block instead of round-tripping through another tool. For scales where each step needs bespoke values or fluid ranges, hand-authoring (covered above) is still the right approach.
+
+The scale config goes under `$extensions["sh.sugarcube"].scale` on the group where you want the generated tokens to live. Sugarcube produces them at build time; once they reach the renderer they're indistinguishable from fluid tokens you've authored yourself.
+
+Two modes are available: **exponential** for ratio-based scales (typically typography) and **multipliers** for arbitrary-step scales (typically spacing).
+
+### Exponential mode
+
+For typography-style scales, where each step is `base × ratio^n`. You can set the same ratio for `min` and `max`, or split them so the scale grows more dramatically on wide screens — a familiar typographic pattern.
+
+```json title="src/design-tokens/type.json"
+{
+  "size": {
+    "step": {
+      "$type": "dimension",
+      "$extensions": {
+        "sh.sugarcube": {
+          "scale": {
+            "mode": "exponential",
+            "base": {
+              "min": { "value": 1, "unit": "rem" },
+              "max": { "value": 1.125, "unit": "rem" }
+            },
+            "ratio": { "min": 1.2, "max": 1.25 },
+            "steps": { "negative": 2, "positive": 5 }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This produces `size.step.-2` through `size.step.5`, each clamping between its computed min and max as the viewport changes. Step `0` is your base — in the example above, `1rem` on small screens growing to `1.125rem` on large ones. Negative steps shrink from there; positive ones grow.
+
+### Multipliers mode
+
+For scales where the steps are named values rather than a fixed ratio — most often spacing. Each token is `base × multiplier`:
+
+```json title="src/design-tokens/space.json"
+{
+  "space": {
+    "$type": "dimension",
+    "$extensions": {
+      "sh.sugarcube": {
+        "scale": {
+          "mode": "multipliers",
+          "base": {
+            "min": { "value": 0.5, "unit": "rem" },
+            "max": { "value": 1, "unit": "rem" }
+          },
+          "multipliers": {
+            "xs": 0.5,
+            "sm": 1,
+            "md": 1.5,
+            "lg": 2,
+            "xl": 3
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+That gives you `space.xs`, `space.sm`, `space.md`, `space.lg`, and `space.xl`. Note that `base` itself isn't generated as a token — it's just the value that "1x" resolves to. In the example above, `sm` has multiplier `1`, so `sm` ends up matching the base. If none of your multipliers equal `1`, the base value never appears as its own token.
+
+#### Pair tokens
+
+Multipliers mode can also generate "from-to" pair tokens — perfect for fluid spacing that *transitions* between named steps as the viewport grows. A `sm-md` pair starts at the `sm` value on small screens and stretches up to `md` on large screens, smoothly clamping in between.
+
+Two formats are supported:
+
+```json frame="none"
+"pairs": "adjacent"
+```
+
+…generates one pair for each consecutive multiplier: `space.xs-sm`, `space.sm-md`, `space.md-lg`, `space.lg-xl`.
+
+```json frame="none"
+"pairs": ["sm-lg", "xs-xl"]
+```
+
+…generates the explicit list. Each name on either side of the dash must exist in `multipliers`.
+
+### Generated token names
+
+<Table>
+| Mode        | Token name        | Example                              |
+| ----------- | ----------------- | ------------------------------------ |
+| Exponential | step number       | `size.step.-1`, `size.step.0`        |
+| Multipliers | multiplier name   | `space.sm`, `space.md`               |
+| Pair        | `<from>-<to>`     | `space.sm-md`, `space.md-lg`         |
+</Table>
+
+Generated tokens behave like any other dimension — they pick up the global `transforms.fluid` viewport, render to `clamp()`, and can be referenced from elsewhere in your design system.
+
+<SiteAside type="note">
+    A scale config replaces what you'd otherwise write by hand. If you also author a token with the same name as one the scale generates, your version wins — handy for one-off overrides without abandoning the scale.
+</SiteAside>
 
 ## Resources
 

--- a/apps/www/src/content/docs/docs/fluid-space-and-type.mdx
+++ b/apps/www/src/content/docs/docs/fluid-space-and-type.mdx
@@ -92,14 +92,12 @@ export default defineConfig({
 
 ## Generating a scale
 
-If you've ever iterated on a type or spacing scale, you know the loop: open [Utopia.fyi](https://utopia.fyi/), tweak the parameters, copy the generated values into your tokens, save, decide you don't like the rhythm, repeat. It works, but you end up spending more time bouncing between tools than thinking about the scale itself.
+Sugarcube can generate type and space scales for you from an `$extensions` block authored alongside your tokens. The feature is heavily inspired by [Utopia](https://utopia.fyi/) but keeps everything in one place, meaning you don't have to bounce between tools. Iterating means editing values within the extension instead of round-tripping Utopia. For scales where each step needs bespoke values or fluid ranges, hand-authoring (covered above) is still the right approach.
 
-Sugarcube can generate scales for you from a single block of configuration authored alongside your tokens. The feature is heavily inspired by Utopia but keeps everything in one place - iterating means editing one config block instead of round-tripping through another tool. For scales where each step needs bespoke values or fluid ranges, hand-authoring (covered above) is still the right approach.
-
-The scale config goes under `$extensions["sh.sugarcube"].scale` on the group where you want the generated tokens to live. Sugarcube produces them at build time; once they reach the renderer they're indistinguishable from fluid tokens you've authored yourself.
+The scale config goes under `$extensions["sh.sugarcube"].scale` on the group where you want the generated tokens to live. Sugarcube produces them at build time; once they reach the renderer they’re indistinguishable from fluid tokens you’ve authored yourself.
 
 <SiteAside type="note">
-    Scale recipes intentionally don't generate token files on disk. The recipe is the source of truth. Keeping it that way avoids the problem of mixing generated and hand-authored tokens.
+    Scale recipes intentionally don’t generate token files on disk. The recipe is the source of truth. Keeping it that way avoids the problem of mixing generated and hand-authored tokens.
 
     The tradeoff is interoperability: other DTCG tools see a group with an unknown `$extensions` block and produce nothing for it, since the children only exist once sugarcube generates them in-memory. If you need the generated tokens to land somewhere other tools can read, hand-author them using the `fluid` extension (covered above) instead.
 </SiteAside>
@@ -108,7 +106,7 @@ Two modes are available: **exponential** for ratio-based scales (typically typog
 
 ### Exponential mode
 
-For typography-style scales, where each step is `base × ratio^n`. You can set the same ratio for `min` and `max`, or split them so the scale grows more dramatically on wide screens — a familiar typographic pattern.
+For typography-style scales, where each step is `base × ratio^n`. You can set the same ratio for `min` and `max`, or split them so the scale grows more dramatically on wide screens — a common typographic pattern.
 
 ```json title="src/design-tokens/type.json"
 {
@@ -169,7 +167,7 @@ That gives you `space.xs`, `space.sm`, `space.md`, `space.lg`, and `space.xl`. N
 
 #### Pair tokens
 
-Multipliers mode can also generate "from-to" pair tokens — perfect for fluid spacing that *transitions* between named steps as the viewport grows. A `sm-md` pair starts at the `sm` value on small screens and stretches up to `md` on large screens, smoothly clamping in between.
+Multipliers mode can also generate "from-to" pair tokens, which are perfect for fluid spacing that *transitions* between named steps as the viewport grows. A `sm-md` pair starts at the `sm` value on small screens and stretches up to `md` on large screens, smoothly clamping in between.
 
 Two formats are supported:
 
@@ -195,10 +193,10 @@ Two formats are supported:
 | Pair        | `<from>-<to>`     | `space.sm-md`, `space.md-lg`         |
 </Table>
 
-Generated tokens behave like any other dimension — they pick up the global `transforms.fluid` viewport, render to `clamp()`, and can be referenced from elsewhere in your design system.
+Generated tokens behave like any other dimension: they pick up the global `transforms.fluid` viewport, render to `clamp()`, and can be referenced from elsewhere in your design system.
 
 <SiteAside type="note">
-    A scale config replaces what you'd otherwise write by hand. If you also author a token with the same name as one the scale generates, your version wins — handy for one-off overrides without abandoning the scale.
+    A scale config replaces what you'd otherwise write by hand. If you also author a token with the same name as one the scale generates, your version wins. This is handy for one-off overrides without abandoning the scale.
 </SiteAside>
 
 ## Resources

--- a/packages/cli/src/prepare-tokens.ts
+++ b/packages/cli/src/prepare-tokens.ts
@@ -47,8 +47,22 @@ export async function prepareTokens(
 
     const { trees, resolved, errors, warnings } = resolveTokens(loaded.trees);
 
-    if (errors.validation.length > 0 || errors.flatten.length > 0 || errors.resolution.length > 0) {
-        const allErrors = [...errors.flatten, ...errors.validation, ...errors.resolution];
+    if (
+        errors.expandTree.length > 0 ||
+        errors.validation.length > 0 ||
+        errors.flatten.length > 0 ||
+        errors.resolution.length > 0
+    ) {
+        const expandTreeAsCommon = errors.expandTree.map((e) => ({
+            message: e.message,
+            source: { sourcePath: e.sourcePath },
+        }));
+        const allErrors = [
+            ...expandTreeAsCommon,
+            ...errors.flatten,
+            ...errors.validation,
+            ...errors.resolution,
+        ];
         const errorsByFile = new Map<string, string[]>();
 
         for (const error of allErrors) {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -10,7 +10,6 @@
  * file loaders, writers, and the Node-side `fillDefaults`.
  */
 
-// Config
 export {
     defineConfig,
     fillDefaultsCore,
@@ -21,26 +20,30 @@ export {
 export type { DefaultDirs } from "./shared/config.js";
 export { DEFAULT_CONFIG } from "./shared/constants/config.js";
 
-// Pipeline primitives (pure) — compose explicitly per output format.
-// e.g. for CSS: groupByContext → assignCSSNames → generateCSSVariables
 export { resolveTokens } from "./shared/resolve-tokens.js";
 export type { ResolveResult, ResolveErrors } from "./shared/resolve-tokens.js";
 export { groupByContext } from "./shared/pipeline/group-by-context.js";
 export { assignCSSNames } from "./shared/pipeline/assign-css-names.js";
 export { generateCSSVariables } from "./shared/generate-css-variables.js";
 
-// Utility-class UnoCSS rules
 export { convertConfigToUnoRules, clearMatchCache } from "./shared/uno-rules.js";
 
-// Formatting helpers
 export { formatCSSVarName } from "./shared/format-css-var-name.js";
 export { createVariableNameResolver } from "./shared/resolve-variable-name.js";
 export { kebabCase } from "./shared/case.js";
 
-// Guards
+export { calculateScale } from "./shared/scale/calculator.js";
+export type { GeneratedStep } from "./shared/scale/calculator.js";
+export type {
+    FluidExtension,
+    ScaleExtension,
+    ExponentialScaleConfig,
+    MultiplierScaleConfig,
+    SugarcubeExtensions,
+} from "./types/extensions.js";
+
 export { isResolvedToken } from "./shared/guards.js";
 
-// Types
 export type {
     InternalConfig,
     SugarcubeConfig,
@@ -79,7 +82,6 @@ export type {
 export type { CSSFileOutput } from "./types/generate.js";
 export type { userConfigSchema } from "./shared/schemas/config.js";
 
-// DTCG types
 export type {
     NodeMetadata,
     Token,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,6 @@
 // Full browser/pure surface (orchestrators, pure config helpers, types, guards, etc.)
 export * from "./client.js";
 
-// Node-flavoured config helpers (these override `validateConfig` and add `fillDefaults`)
 export { fillDefaults, validateConfig } from "./node/config/normalize.js";
 export {
     configFileExists,
@@ -21,18 +20,14 @@ export {
     loadSugarcubeConfig,
 } from "./node/config/load.js";
 
-// Resolver discovery + static analysis (Node filesystem only)
 export { findResolverDocument } from "./node/resolver/find.js";
 export type { ResolverDiscoveryResult } from "./node/resolver/find.js";
 export { extractFileRefs } from "./node/resolver/extract-refs.js";
 export type { ExtractFileRefsResult } from "./node/resolver/extract-refs.js";
 
-// Node loader (the first step of the pipeline — reads from disk)
 export { loadTokens } from "./node/load-tokens.js";
 export type { LoadResult } from "./node/load-tokens.js";
 
-// Perf / instrumentation (Node-only: uses process.hrtime, process.memoryUsage, etc.)
 export { PerfMonitor, Instrumentation } from "./node/perf.js";
 
-// Filesystem writers
 export { writeCSSVariablesToDisk, writeCSSUtilitiesToDisk } from "./node/write-css.js";

--- a/packages/core/src/shared/constants/error-messages.ts
+++ b/packages/core/src/shared/constants/error-messages.ts
@@ -92,6 +92,18 @@ export const ErrorMessages = {
             `Expected value to be one of [${enumValues.join(", ")}], but got ${String(
                 value
             )} at ${path}`,
+        SCALE_CONTAINS_REFERENCE: (path: string) =>
+            `Scale config at ${path} cannot contain references — recipes must use literal numbers and units.`,
+        SCALE_INVALID_RATIO: (value: unknown, path: string) =>
+            `Invalid exponential ratio at ${path}: '${value}'. Ratio must be greater than 1 (a ratio ≤ 1 produces a flat or inverted scale).`,
+        SCALE_EMPTY_MULTIPLIERS: (path: string) =>
+            `Multipliers at ${path} must be a non-empty record of step name → number.`,
+        SCALE_INVALID_PAIRS: (path: string) =>
+            `Invalid \`pairs\` at ${path}: must be the string "adjacent" or an array of pair names like ["sm-lg"].`,
+        SCALE_INVALID_PAIR_ENTRY: (value: unknown, path: string) =>
+            `Invalid pair entry at ${path}: ${String(value)}. Each pair must be a string in the form "<from>-<to>".`,
+        SCALE_PAIR_UNKNOWN_MULTIPLIER: (name: string, path: string) =>
+            `Pair at ${path} references unknown multiplier '${name}'. The name must match a key in the scale's \`multipliers\`.`,
     },
     RESOLVE: {
         CIRCULAR_REFERENCE: (path: string, ref: string) =>

--- a/packages/core/src/shared/pipeline/expand-generators.ts
+++ b/packages/core/src/shared/pipeline/expand-generators.ts
@@ -1,0 +1,92 @@
+/**
+ * Materializes Sugarcube generator extensions into tree nodes during the
+ * expand pass. A "generator" extension is one where the user authors a
+ * recipe at a group level (e.g. sh.sugarcube.scale) and sugarcube
+ * synthesizes the resulting child tokens at build time.
+ *
+ * Validation runs here too: a malformed scale recipe surfaces an
+ * ExpandError, the group is left intact (without materialized children),
+ * and the rest of the pipeline continues.
+ */
+
+import type { Token, TokenGroup } from "../../types/dtcg.js";
+import type { ScaleExtension } from "../../types/extensions.js";
+import type { TokenSource, TokenTree } from "../../types/tokens.js";
+import { resolveScaleExtension } from "../scale/resolver.js";
+import { validateScaleExtension } from "../validators/scale.js";
+import type { ExpandError } from "./expand.js";
+
+type GeneratorResult = {
+    trees: TokenTree[];
+    errors: ExpandError[];
+};
+
+export function expandGenerators(trees: TokenTree[]): GeneratorResult {
+    const result: TokenTree[] = [];
+    const errors: ExpandError[] = [];
+
+    for (const tree of trees) {
+        const source: TokenSource = {
+            sourcePath: tree.sourcePath,
+            ...(tree.context && { context: tree.context }),
+        };
+        const path: string[] = [];
+        const expanded = expandGroup(tree.tokens, path, source, errors);
+        result.push(expanded === tree.tokens ? tree : { ...tree, tokens: expanded });
+    }
+
+    return { trees: result, errors };
+}
+
+function expandGroup(
+    node: TokenGroup,
+    path: string[],
+    source: TokenSource,
+    errors: ExpandError[]
+): TokenGroup {
+    let result: TokenGroup | null = null;
+
+    const sugarcube = node.$extensions?.["sh.sugarcube"] as { scale?: unknown } | undefined;
+    const scaleExt = sugarcube?.scale;
+    if (scaleExt !== undefined) {
+        const errorPath = [...path, "$extensions", "sh.sugarcube", "scale"].join(".");
+        const validationErrors = validateScaleExtension(scaleExt, errorPath, source);
+
+        if (validationErrors.length > 0) {
+            for (const err of validationErrors) {
+                errors.push({
+                    path: err.path,
+                    message: err.message,
+                    sourcePath: err.source.sourcePath,
+                });
+            }
+        } else {
+            const generated = resolveScaleExtension(scaleExt as ScaleExtension);
+            for (const name in generated) {
+                if (name in node) continue;
+                if (result === null) result = { ...node };
+                result[name] = generated[name];
+            }
+        }
+    }
+
+    for (const key in node) {
+        if (key.startsWith("$") && key !== "$root") continue;
+        const value = (node as Record<string, unknown>)[key];
+        if (isToken(value)) continue;
+        if (typeof value !== "object" || value === null) continue;
+        path.push(key);
+        const expanded = expandGroup(value as TokenGroup, path, source, errors);
+        path.pop();
+        if (expanded !== value) {
+            if (result === null) result = { ...node };
+            result[key] = expanded;
+        }
+    }
+
+    return result ?? node;
+}
+
+function isToken(value: unknown): value is Token {
+    return typeof value === "object" && value !== null && "$value" in value;
+}

--- a/packages/core/src/shared/pipeline/expand-generators.ts
+++ b/packages/core/src/shared/pipeline/expand-generators.ts
@@ -1,17 +1,18 @@
 /**
- * Materializes Sugarcube generator extensions into tree nodes during the
+ * Materialises sugarcube generator extensions into tree nodes during the
  * expand pass. A "generator" extension is one where the user authors a
  * recipe at a group level (e.g. sh.sugarcube.scale) and sugarcube
  * synthesizes the resulting child tokens at build time.
  *
  * Validation runs here too: a malformed scale recipe surfaces an
- * ExpandError, the group is left intact (without materialized children),
+ * ExpandError, the group is left intact (without materialised children),
  * and the rest of the pipeline continues.
  */
 
-import type { Token, TokenGroup } from "../../types/dtcg.js";
+import type { TokenGroup } from "../../types/dtcg.js";
 import type { ScaleExtension } from "../../types/extensions.js";
 import type { TokenSource, TokenTree } from "../../types/tokens.js";
+import { isToken } from "../guards.js";
 import { resolveScaleExtension } from "../scale/resolver.js";
 import { validateScaleExtension } from "../validators/scale.js";
 import type { ExpandError } from "./expand.js";
@@ -85,8 +86,4 @@ function expandGroup(
     }
 
     return result ?? node;
-}
-
-function isToken(value: unknown): value is Token {
-    return typeof value === "object" && value !== null && "$value" in value;
 }

--- a/packages/core/src/shared/pipeline/expand-scale.ts
+++ b/packages/core/src/shared/pipeline/expand-scale.ts
@@ -1,7 +1,6 @@
 /**
- * Materialises sugarcube generator extensions into tree nodes during the
- * expand pass. A "generator" extension is one where the user authors a
- * recipe at a group level (e.g. sh.sugarcube.scale) and sugarcube
+ * Materialises sh.sugarcube.scale recipes into tree nodes during the
+ * expand pass. A scale recipe is authored at a group level and sugarcube
  * synthesizes the resulting child tokens at build time.
  *
  * Validation runs here too: a malformed scale recipe surfaces an
@@ -17,12 +16,12 @@ import { resolveScaleExtension } from "../scale/resolver.js";
 import { validateScaleExtension } from "../validators/scale.js";
 import type { ExpandError } from "./expand.js";
 
-type GeneratorResult = {
+type ExpandScaleResult = {
     trees: TokenTree[];
     errors: ExpandError[];
 };
 
-export function expandGenerators(trees: TokenTree[]): GeneratorResult {
+export function expandScale(trees: TokenTree[]): ExpandScaleResult {
     const result: TokenTree[] = [];
     const errors: ExpandError[] = [];
 

--- a/packages/core/src/shared/pipeline/expand.ts
+++ b/packages/core/src/shared/pipeline/expand.ts
@@ -2,7 +2,7 @@ import type { Token, TokenGroup } from "../../types/dtcg.js";
 import type { TokenTree } from "../../types/tokens.js";
 import { ErrorMessages } from "../constants/error-messages.js";
 import { hasRef } from "../guards.js";
-import { expandGenerators } from "./expand-generators.js";
+import { expandScale } from "./expand-scale.js";
 import { mergeGroups } from "./merge-groups.js";
 
 export type ExpandError = {
@@ -82,7 +82,7 @@ function containsRefsOrExtends(obj: unknown): boolean {
  * Three passes:
  * 1. $ref: convert JSON Pointer references to curly brace format
  * 2. $extends: resolve group inheritance via deep merge
- * 3. generators: expand sh.sugarcube.scale (and future palette) recipes
+ * 3. scale: expand sh.sugarcube.scale recipes into child tokens
  *
  * For token refs: { "$ref": "#/colors/blue" } becomes { "$value": "{colors.blue}" }
  * For group refs: { "$ref": "#/button" } inlines the target group content
@@ -126,10 +126,10 @@ export function expand(trees: TokenTree[]): ExpandResult {
     // Third pass: expand scale recipes into the tokens they describe.
     // Runs after refs/extends settle, so a recipe inherited from another
     // group resolves before it generates anything.
-    const { trees: withGenerators, errors: generatorErrors } = expandGenerators(results);
-    errors.push(...generatorErrors);
+    const { trees: withScale, errors: scaleErrors } = expandScale(results);
+    errors.push(...scaleErrors);
 
-    return { trees: withGenerators, errors };
+    return { trees: withScale, errors };
 }
 
 // ============================================

--- a/packages/core/src/shared/pipeline/expand.ts
+++ b/packages/core/src/shared/pipeline/expand.ts
@@ -2,6 +2,7 @@ import type { Token, TokenGroup } from "../../types/dtcg.js";
 import type { TokenTree } from "../../types/tokens.js";
 import { ErrorMessages } from "../constants/error-messages.js";
 import { hasRef } from "../guards.js";
+import { expandGenerators } from "./expand-generators.js";
 import { mergeGroups } from "./merge-groups.js";
 
 export type ExpandError = {
@@ -75,15 +76,18 @@ function containsRefsOrExtends(obj: unknown): boolean {
 }
 
 /**
- * Expand $ref and $extends in token trees before flattening.
+ * Expand $ref, $extends, and sugarcube generator extensions in token trees
+ * before flattening.
  *
- * Two passes:
+ * Three passes:
  * 1. $ref: convert JSON Pointer references to curly brace format
  * 2. $extends: resolve group inheritance via deep merge
+ * 3. generators: expand sh.sugarcube.scale (and future palette) recipes
  *
  * For token refs: { "$ref": "#/colors/blue" } becomes { "$value": "{colors.blue}" }
  * For group refs: { "$ref": "#/button" } inlines the target group content
  * For extends: { "$extends": "{button}" } inherits from the button group
+ * For generators: a group's sh.sugarcube.scale recipe expands to child tokens
  */
 export function expand(trees: TokenTree[]): ExpandResult {
     const results: TokenTree[] = [];
@@ -119,7 +123,13 @@ export function expand(trees: TokenTree[]): ExpandResult {
         results.push({ ...tree, tokens: extendsExpanded });
     }
 
-    return { trees: results, errors };
+    // Third pass: expand scale recipes into the tokens they describe.
+    // Runs after refs/extends settle, so a recipe inherited from another
+    // group resolves before it generates anything.
+    const { trees: withGenerators, errors: generatorErrors } = expandGenerators(results);
+    errors.push(...generatorErrors);
+
+    return { trees: withGenerators, errors };
 }
 
 // ============================================

--- a/packages/core/src/shared/renderers/css/dimension.ts
+++ b/packages/core/src/shared/renderers/css/dimension.ts
@@ -1,5 +1,6 @@
+import type { FluidExtension } from "../../../types/extensions.js";
 import type { CSSRenderOptions, SimpleCSSProperties } from "../../../types/render.js";
-import type { Dimension, FluidDimension, TokenValue } from "../../../types/tokens.js";
+import type { Dimension, TokenValue } from "../../../types/tokens.js";
 import { isReference } from "../../guards.js";
 
 function normalizeToPixels(value: Dimension, rootSize = 16): number {
@@ -7,17 +8,17 @@ function normalizeToPixels(value: Dimension, rootSize = 16): number {
 }
 
 function convertFluidDimension(
-    value: FluidDimension,
+    value: FluidExtension,
     options: CSSRenderOptions
 ): SimpleCSSProperties {
     const { min, max } = value;
-    const fluidConfig = options.fluidConfig;
+    const viewport = options.fluidConfig;
     const rootSize = 16; // TODO: make this configurable??
 
     const minSize = normalizeToPixels(min, rootSize);
     const maxSize = normalizeToPixels(max, rootSize);
-    const minViewport = fluidConfig.min;
-    const maxViewport = fluidConfig.max;
+    const minViewport = viewport.min;
+    const maxViewport = viewport.max;
 
     if (minSize === maxSize) {
         return {

--- a/packages/core/src/shared/scale/calculator.ts
+++ b/packages/core/src/shared/scale/calculator.ts
@@ -1,0 +1,107 @@
+import type { Dimension } from "../../types/dtcg.js";
+import type {
+    ExponentialScaleConfig,
+    MultiplierScaleConfig,
+    ScaleExtension,
+} from "../../types/extensions.js";
+
+export type GeneratedStep = {
+    name: string;
+    min: Dimension;
+    max: Dimension;
+};
+
+const ROUND_PRECISION = 4;
+
+export function calculateScale(config: ScaleExtension): GeneratedStep[] {
+    return config.mode === "exponential"
+        ? calculateExponentialScale(config)
+        : calculateMultiplierScale(config);
+}
+
+function calculateExponentialScale(config: ExponentialScaleConfig): GeneratedStep[] {
+    const { base, ratio, steps } = config;
+    const result: GeneratedStep[] = [];
+
+    for (let i = -steps.negative; i <= steps.positive; i++) {
+        result.push({
+            name: String(i),
+            min: {
+                value: roundTo(base.min.value * ratio.min ** i, ROUND_PRECISION),
+                unit: base.min.unit,
+            },
+            max: {
+                value: roundTo(base.max.value * ratio.max ** i, ROUND_PRECISION),
+                unit: base.max.unit,
+            },
+        });
+    }
+
+    return result;
+}
+
+function calculateMultiplierScale(config: MultiplierScaleConfig): GeneratedStep[] {
+    const { base, multipliers, pairs } = config;
+    const result: GeneratedStep[] = [];
+
+    for (const [name, multiplier] of Object.entries(multipliers)) {
+        result.push({
+            name,
+            min: {
+                value: roundTo(base.min.value * multiplier, ROUND_PRECISION),
+                unit: base.min.unit,
+            },
+            max: {
+                value: roundTo(base.max.value * multiplier, ROUND_PRECISION),
+                unit: base.max.unit,
+            },
+        });
+    }
+
+    const pairList = resolvePairList(pairs, Object.keys(multipliers));
+    for (const [fromName, toName] of pairList) {
+        const fromMultiplier = multipliers[fromName];
+        const toMultiplier = multipliers[toName];
+        if (fromMultiplier === undefined || toMultiplier === undefined) continue;
+        result.push({
+            name: `${fromName}-${toName}`,
+            min: {
+                value: roundTo(base.min.value * fromMultiplier, ROUND_PRECISION),
+                unit: base.min.unit,
+            },
+            max: {
+                value: roundTo(base.max.value * toMultiplier, ROUND_PRECISION),
+                unit: base.max.unit,
+            },
+        });
+    }
+
+    return result;
+}
+
+function resolvePairList(
+    pairs: MultiplierScaleConfig["pairs"],
+    names: string[]
+): [string, string][] {
+    if (pairs === undefined) return [];
+
+    if (pairs === "adjacent") {
+        const result: [string, string][] = [];
+        for (let i = 0; i < names.length - 1; i++) {
+            const from = names[i];
+            const to = names[i + 1];
+            if (from && to) result.push([from, to]);
+        }
+        return result;
+    }
+
+    return pairs.map((spec) => {
+        const dash = spec.indexOf("-");
+        return [spec.slice(0, dash), spec.slice(dash + 1)] as [string, string];
+    });
+}
+
+function roundTo(value: number, precision: number): number {
+    const factor = 10 ** precision;
+    return Math.round(value * factor) / factor;
+}

--- a/packages/core/src/shared/scale/resolver.ts
+++ b/packages/core/src/shared/scale/resolver.ts
@@ -1,0 +1,34 @@
+/**
+ * Expands a scale recipe into virtual DTCG dimension tokens.
+ * Each step gets a `$type: "dimension"` token whose `$value` is the max
+ * end of the fluid range, with the full fluid bounds carried on the
+ * sh.sugarcube.fluid extension. The fluid renderer reads from there
+ * to emit clamp(), so virtual scale tokens are indistinguishable from
+ * manually-authored fluid tokens once they reach the renderer.
+ */
+
+import type { Token } from "../../types/dtcg.js";
+import type { ScaleExtension } from "../../types/extensions.js";
+import { calculateScale } from "./calculator.js";
+
+export function resolveScaleExtension(scaleConfig: ScaleExtension): Record<string, Token> {
+    const steps = calculateScale(scaleConfig);
+    const tokens: Record<string, Token> = {};
+
+    for (const step of steps) {
+        tokens[step.name] = {
+            $type: "dimension",
+            $value: step.max,
+            $extensions: {
+                "sh.sugarcube": {
+                    fluid: {
+                        min: step.min,
+                        max: step.max,
+                    },
+                },
+            },
+        };
+    }
+
+    return tokens;
+}

--- a/packages/core/src/shared/validators/scale.ts
+++ b/packages/core/src/shared/validators/scale.ts
@@ -1,0 +1,312 @@
+/**
+ * Validates the shape of an `sh.sugarcube.scale` extension config.
+ *
+ * Scale expansion runs before reference resolution, so any DTCG reference
+ * inside the config would never resolve and is rejected at validation
+ * time. Other rules cover required fields, mode-specific fields, and
+ * exponential ratio bounds.
+ */
+
+import type { TokenSource } from "../../types/tokens.js";
+import type { ValidationError } from "../../types/validate.js";
+import { ErrorMessages } from "../constants/error-messages.js";
+import { isReference } from "../guards.js";
+
+export function validateScaleExtension(
+    ext: unknown,
+    path: string,
+    source: TokenSource
+): ValidationError[] {
+    const errors: ValidationError[] = [];
+
+    if (!isObject(ext)) {
+        errors.push({
+            path,
+            message: ErrorMessages.VALIDATE.INVALID_TYPE("object", ext, path),
+            source,
+        });
+        return errors;
+    }
+
+    collectReferenceErrors(ext, path, source, errors);
+
+    const mode = ext.mode;
+    if (mode === undefined) {
+        errors.push({
+            path: `${path}.mode`,
+            message: ErrorMessages.VALIDATE.MISSING_REQUIRED_PROPERTY("mode", path),
+            source,
+        });
+    } else if (mode !== "exponential" && mode !== "multipliers") {
+        errors.push({
+            path: `${path}.mode`,
+            message: ErrorMessages.VALIDATE.INVALID_ENUM_VALUE(
+                ["exponential", "multipliers"],
+                mode,
+                `${path}.mode`
+            ),
+            source,
+        });
+    }
+
+    validateBase(ext.base, `${path}.base`, source, errors);
+
+    if (mode === "exponential") {
+        validateExponentialFields(ext, path, source, errors);
+    } else if (mode === "multipliers") {
+        validateMultiplierFields(ext, path, source, errors);
+    }
+
+    return errors;
+}
+
+function validateBase(
+    value: unknown,
+    path: string,
+    source: TokenSource,
+    errors: ValidationError[]
+): void {
+    if (value === undefined) {
+        errors.push({
+            path,
+            message: ErrorMessages.VALIDATE.MISSING_REQUIRED_PROPERTY("base", path),
+            source,
+        });
+        return;
+    }
+
+    if (!isObject(value)) {
+        errors.push({
+            path,
+            message: ErrorMessages.VALIDATE.INVALID_TYPE("object", value, path),
+            source,
+        });
+        return;
+    }
+
+    validateDimension(value.min, `${path}.min`, source, errors);
+    validateDimension(value.max, `${path}.max`, source, errors);
+}
+
+function validateDimension(
+    value: unknown,
+    path: string,
+    source: TokenSource,
+    errors: ValidationError[]
+): void {
+    if (!isObject(value)) {
+        errors.push({
+            path,
+            message: ErrorMessages.VALIDATE.INVALID_DIMENSION(value, path),
+            source,
+        });
+        return;
+    }
+
+    const numericValue = value.value;
+    const unit = value.unit;
+
+    if (typeof numericValue !== "number") {
+        errors.push({
+            path: `${path}.value`,
+            message: ErrorMessages.VALIDATE.INVALID_NUMBER(numericValue, `${path}.value`),
+            source,
+        });
+    }
+
+    if (unit !== "rem" && unit !== "px") {
+        errors.push({
+            path: `${path}.unit`,
+            message: ErrorMessages.VALIDATE.INVALID_DIMENSION_UNIT(unit, `${path}.unit`),
+            source,
+        });
+    }
+}
+
+function validateExponentialFields(
+    ext: Record<string, unknown>,
+    path: string,
+    source: TokenSource,
+    errors: ValidationError[]
+): void {
+    const ratio = ext.ratio;
+    if (ratio === undefined) {
+        errors.push({
+            path: `${path}.ratio`,
+            message: ErrorMessages.VALIDATE.MISSING_REQUIRED_PROPERTY("ratio", path),
+            source,
+        });
+    } else if (!isObject(ratio)) {
+        errors.push({
+            path: `${path}.ratio`,
+            message: ErrorMessages.VALIDATE.INVALID_TYPE("object", ratio, `${path}.ratio`),
+            source,
+        });
+    } else {
+        for (const key of ["min", "max"] as const) {
+            const v = ratio[key];
+            if (typeof v !== "number") {
+                errors.push({
+                    path: `${path}.ratio.${key}`,
+                    message: ErrorMessages.VALIDATE.INVALID_NUMBER(v, `${path}.ratio.${key}`),
+                    source,
+                });
+            } else if (v <= 1) {
+                errors.push({
+                    path: `${path}.ratio.${key}`,
+                    message: ErrorMessages.VALIDATE.SCALE_INVALID_RATIO(v, `${path}.ratio.${key}`),
+                    source,
+                });
+            }
+        }
+    }
+
+    const steps = ext.steps;
+    if (steps === undefined) {
+        errors.push({
+            path: `${path}.steps`,
+            message: ErrorMessages.VALIDATE.MISSING_REQUIRED_PROPERTY("steps", path),
+            source,
+        });
+    } else if (!isObject(steps)) {
+        errors.push({
+            path: `${path}.steps`,
+            message: ErrorMessages.VALIDATE.INVALID_TYPE("object", steps, `${path}.steps`),
+            source,
+        });
+    } else {
+        for (const key of ["negative", "positive"] as const) {
+            const v = steps[key];
+            if (typeof v !== "number" || !Number.isInteger(v) || v < 0) {
+                errors.push({
+                    path: `${path}.steps.${key}`,
+                    message: ErrorMessages.VALIDATE.INVALID_TYPE(
+                        "non-negative integer",
+                        v,
+                        `${path}.steps.${key}`
+                    ),
+                    source,
+                });
+            }
+        }
+    }
+}
+
+function validateMultiplierFields(
+    ext: Record<string, unknown>,
+    path: string,
+    source: TokenSource,
+    errors: ValidationError[]
+): void {
+    const multipliers = ext.multipliers;
+    if (multipliers === undefined) {
+        errors.push({
+            path: `${path}.multipliers`,
+            message: ErrorMessages.VALIDATE.MISSING_REQUIRED_PROPERTY("multipliers", path),
+            source,
+        });
+    } else if (!isObject(multipliers) || Object.keys(multipliers).length === 0) {
+        errors.push({
+            path: `${path}.multipliers`,
+            message: ErrorMessages.VALIDATE.SCALE_EMPTY_MULTIPLIERS(`${path}.multipliers`),
+            source,
+        });
+    } else {
+        for (const [key, v] of Object.entries(multipliers)) {
+            if (typeof v !== "number") {
+                errors.push({
+                    path: `${path}.multipliers.${key}`,
+                    message: ErrorMessages.VALIDATE.INVALID_NUMBER(v, `${path}.multipliers.${key}`),
+                    source,
+                });
+            }
+        }
+    }
+
+    validatePairs(
+        ext.pairs,
+        isObject(multipliers) ? Object.keys(multipliers) : [],
+        `${path}.pairs`,
+        source,
+        errors
+    );
+}
+
+function validatePairs(
+    value: unknown,
+    multiplierNames: string[],
+    path: string,
+    source: TokenSource,
+    errors: ValidationError[]
+): void {
+    if (value === undefined) return;
+    if (value === "adjacent") return;
+
+    if (!Array.isArray(value)) {
+        errors.push({
+            path,
+            message: ErrorMessages.VALIDATE.SCALE_INVALID_PAIRS(path),
+            source,
+        });
+        return;
+    }
+
+    value.forEach((entry, i) => {
+        if (typeof entry !== "string" || !entry.includes("-")) {
+            errors.push({
+                path: `${path}[${i}]`,
+                message: ErrorMessages.VALIDATE.SCALE_INVALID_PAIR_ENTRY(entry, `${path}[${i}]`),
+                source,
+            });
+            return;
+        }
+        const dash = entry.indexOf("-");
+        const from = entry.slice(0, dash);
+        const to = entry.slice(dash + 1);
+        for (const name of [from, to]) {
+            if (!multiplierNames.includes(name)) {
+                errors.push({
+                    path: `${path}[${i}]`,
+                    message: ErrorMessages.VALIDATE.SCALE_PAIR_UNKNOWN_MULTIPLIER(
+                        name,
+                        `${path}[${i}]`
+                    ),
+                    source,
+                });
+            }
+        }
+    });
+}
+
+function collectReferenceErrors(
+    value: unknown,
+    path: string,
+    source: TokenSource,
+    errors: ValidationError[]
+): void {
+    if (isReference(value)) {
+        errors.push({
+            path,
+            message: ErrorMessages.VALIDATE.SCALE_CONTAINS_REFERENCE(path),
+            source,
+        });
+        return;
+    }
+
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => {
+            collectReferenceErrors(item, `${path}[${index}]`, source, errors);
+        });
+        return;
+    }
+
+    if (isObject(value)) {
+        for (const [key, child] of Object.entries(value)) {
+            collectReferenceErrors(child, `${path}.${key}`, source, errors);
+        }
+    }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -207,30 +207,35 @@ export type PresetBinding = {
 };
 
 /**
- * A scale binding — treats a group of matching tokens as a single scale,
- * controlled by base / spread sliders.
+ * A scale binding — declares a panel control for a group of fluid tokens.
+ *
+ * The studio dispatches purely on whether a recipe (`sh.sugarcube.scale`
+ * extension) is authored at the bound path:
+ * - Recipe present → recipe-aware controls; the recipe's `mode` field
+ *   tells the studio whether to render exponential or multipliers UI.
+ * - No recipe → bulk controls (base + spread) and per-step inputs render
+ *   together for direct editing of the concrete tokens.
+ *
+ * @example
+ * { type: "scale", token: "size.step.*", base: "size.step.0" }
  */
 export type ScaleBinding = {
     type: "scale";
-    /** Glob pattern matching the tokens that make up the scale. */
+    /** Glob pattern (or concrete path) matching the scale's tokens. */
     token: string;
     /** Optional label override. */
     label?: string;
     /**
-     * The path of the step that should be treated as the scale's anchor —
-     * the step whose current value is `1.0` multiplier relative to itself,
-     * and which the "base" slider directly controls. Required for
-     * cascade-mode scale bindings.
-     *
-     * @example
-     * { type: "scale", token: "size.step.*", base: "size.step.0" }
+     * The path of the step that anchors the bulk slider. The slider's
+     * value directly controls this step's max-viewport value, and other
+     * steps adjust proportionally.
      */
     base?: string;
-    /** Slider minimum. */
+    /** Bulk slider minimum. */
     min?: number;
-    /** Slider maximum. */
+    /** Bulk slider maximum. */
     max?: number;
-    /** Slider step increment. */
+    /** Bulk slider step increment. */
     step?: number;
 };
 

--- a/packages/core/src/types/extensions.ts
+++ b/packages/core/src/types/extensions.ts
@@ -10,11 +10,41 @@ export type FluidExtension = {
 };
 
 /**
+ * Recipe for generating a family of dimension tokens from a single
+ * group node. Authored under `$extensions["sh.sugarcube"].scale`;
+ * sugarcube materializes the resulting tokens during the expand pass.
+ */
+export type ScaleExtension = ExponentialScaleConfig | MultiplierScaleConfig;
+
+type BaseScaleConfig = {
+    base: { min: Dimension; max: Dimension };
+};
+
+export type ExponentialScaleConfig = BaseScaleConfig & {
+    mode: "exponential";
+    ratio: { min: number; max: number };
+    steps: { negative: number; positive: number };
+};
+
+export type MultiplierScaleConfig = BaseScaleConfig & {
+    mode: "multipliers";
+    multipliers: Record<string, number>;
+    /**
+     * Generate space pairs from named multipliers.
+     * - omitted: no pairs
+     * - "adjacent": one pair for each consecutive multiplier (sm-md, md-lg, …)
+     * - string[]: explicit list like ["sm-lg", "xs-xl"]; each name must exist in `multipliers`
+     */
+    pairs?: "adjacent" | string[];
+};
+
+/**
  * Sugarcube-specific extensions following DTCG $extensions spec.
  * Uses reverse domain notation per DTCG specification.
  */
 export type SugarcubeExtensions = {
     "sh.sugarcube"?: {
         fluid?: FluidExtension;
+        scale?: ScaleExtension;
     };
 };

--- a/packages/core/tests/benchmarks/pipeline.bench.ts
+++ b/packages/core/tests/benchmarks/pipeline.bench.ts
@@ -2,6 +2,7 @@ import { bench, describe } from "vitest";
 import { fillDefaults } from "../../src/node/config/normalize.js";
 import { loadTokens } from "../../src/node/load-tokens.js";
 import { assignCSSNames } from "../../src/shared/pipeline/assign-css-names.js";
+import { expandScale } from "../../src/shared/pipeline/expand-scale.js";
 import { expand } from "../../src/shared/pipeline/expand.js";
 import { groupByContext } from "../../src/shared/pipeline/group-by-context.js";
 import { resolveTokens } from "../../src/shared/resolve-tokens.js";
@@ -305,6 +306,73 @@ describe("pipeline", () => {
 
         bench("with $extends - wide (100 groups, 5 tokens each)", () => {
             expand([buildExtendsTree(100, 5)]);
+        });
+    });
+
+    describe("expand-scale stage", () => {
+        function buildPlainGroupTree(groupCount: number, tokensPerGroup: number): TokenTree {
+            const tokens: Record<string, unknown> = {};
+            for (let g = 0; g < groupCount; g++) {
+                const group: Record<string, unknown> = { $type: "color" };
+                for (let t = 0; t < tokensPerGroup; t++) {
+                    group[`token-${t}`] = { $value: "#ff0000" };
+                }
+                tokens[`group-${g}`] = group;
+            }
+            return { sourcePath: "bench.json", tokens: tokens as TokenGroup };
+        }
+
+        function buildScaleRecipeTree(
+            recipeCount: number,
+            stepsPositive: number,
+            stepsNegative: number
+        ): TokenTree {
+            const tokens: Record<string, unknown> = {};
+            for (let g = 0; g < recipeCount; g++) {
+                tokens[`scale-${g}`] = {
+                    $extensions: {
+                        "sh.sugarcube": {
+                            scale: {
+                                mode: "exponential",
+                                base: {
+                                    min: { value: 1, unit: "rem" },
+                                    max: { value: 1.25, unit: "rem" },
+                                },
+                                ratio: { min: 1.2, max: 1.25 },
+                                steps: { negative: stepsNegative, positive: stepsPositive },
+                            },
+                        },
+                    },
+                };
+            }
+            return { sourcePath: "bench.json", tokens: tokens as TokenGroup };
+        }
+
+        // Walk-only: measures the recursive group walk with no recipes to expand.
+        bench("walk only - 100 groups, 10 tokens each (no recipes)", () => {
+            expandScale([buildPlainGroupTree(100, 10)]);
+        });
+
+        bench("walk only - 1,000 groups, 10 tokens each (no recipes)", () => {
+            expandScale([buildPlainGroupTree(1000, 10)]);
+        });
+
+        bench("walk only - 10,000 groups, 10 tokens each (no recipes)", () => {
+            expandScale([buildPlainGroupTree(10000, 10)]);
+        });
+
+        // Recipe-heavy: measures validate + calculate + merge per recipe.
+        // Same shape as walk-only but every group is a recipe.
+        bench("recipes - 100 recipes × 8 steps", () => {
+            expandScale([buildScaleRecipeTree(100, 5, 2)]);
+        });
+
+        bench("recipes - 1,000 recipes × 8 steps", () => {
+            expandScale([buildScaleRecipeTree(1000, 5, 2)]);
+        });
+
+        bench("recipes - 10 recipes × 100 steps (deep recipe)", () => {
+            expandScale([buildScaleRecipeTree(10, 80, 19)]);
         });
     });
 });

--- a/packages/core/tests/scale-calculator.test.ts
+++ b/packages/core/tests/scale-calculator.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import { calculateScale } from "../src/shared/scale/calculator.js";
+import type { ExponentialScaleConfig, MultiplierScaleConfig } from "../src/types/extensions.js";
+
+const remBase = (min: number, max: number) => ({
+    min: { value: min, unit: "rem" as const },
+    max: { value: max, unit: "rem" as const },
+});
+
+describe("calculateScale - exponential mode", () => {
+    it("generates negative + zero + positive steps for the configured count", () => {
+        const config: ExponentialScaleConfig = {
+            mode: "exponential",
+            base: remBase(1, 1.125),
+            ratio: { min: 1.2, max: 1.25 },
+            steps: { negative: 2, positive: 5 },
+        };
+
+        const result = calculateScale(config);
+
+        expect(result).toHaveLength(8);
+        expect(result.map((step) => step.name)).toEqual(["-2", "-1", "0", "1", "2", "3", "4", "5"]);
+    });
+
+    it("computes step values as base × ratio^n with separate min/max ratios", () => {
+        const config: ExponentialScaleConfig = {
+            mode: "exponential",
+            base: remBase(1, 1.125),
+            ratio: { min: 1.2, max: 1.25 },
+            steps: { negative: 1, positive: 2 },
+        };
+
+        const result = calculateScale(config);
+
+        expect(result[0]).toEqual({
+            name: "-1",
+            min: { value: 0.8333, unit: "rem" },
+            max: { value: 0.9, unit: "rem" },
+        });
+        expect(result[1]).toEqual({
+            name: "0",
+            min: { value: 1, unit: "rem" },
+            max: { value: 1.125, unit: "rem" },
+        });
+        expect(result[2]).toEqual({
+            name: "1",
+            min: { value: 1.2, unit: "rem" },
+            max: { value: 1.4063, unit: "rem" },
+        });
+        expect(result[3]).toEqual({
+            name: "2",
+            min: { value: 1.44, unit: "rem" },
+            max: { value: 1.7578, unit: "rem" },
+        });
+    });
+
+    it("returns flat values when min and max ratios both equal 1", () => {
+        const config: ExponentialScaleConfig = {
+            mode: "exponential",
+            base: remBase(1, 1),
+            ratio: { min: 1, max: 1 },
+            steps: { negative: 2, positive: 2 },
+        };
+
+        const result = calculateScale(config);
+
+        for (const step of result) {
+            expect(step.min.value).toBe(1);
+            expect(step.max.value).toBe(1);
+        }
+    });
+
+    it("preserves the unit from the base config on every step", () => {
+        const config: ExponentialScaleConfig = {
+            mode: "exponential",
+            base: {
+                min: { value: 16, unit: "px" },
+                max: { value: 18, unit: "px" },
+            },
+            ratio: { min: 1.2, max: 1.25 },
+            steps: { negative: 1, positive: 1 },
+        };
+
+        const result = calculateScale(config);
+
+        for (const step of result) {
+            expect(step.min.unit).toBe("px");
+            expect(step.max.unit).toBe("px");
+        }
+    });
+});
+
+describe("calculateScale - multipliers mode", () => {
+    it("generates one step per named multiplier", () => {
+        const config: MultiplierScaleConfig = {
+            mode: "multipliers",
+            base: remBase(0.875, 1),
+            multipliers: { xs: 0.75, sm: 1, md: 1.5 },
+        };
+
+        const result = calculateScale(config);
+
+        expect(result).toHaveLength(3);
+        expect(result.map((step) => step.name)).toEqual(["xs", "sm", "md"]);
+    });
+
+    it("computes each step as base × multiplier", () => {
+        const config: MultiplierScaleConfig = {
+            mode: "multipliers",
+            base: remBase(1, 2),
+            multipliers: { sm: 1, md: 1.5, lg: 2 },
+        };
+
+        const result = calculateScale(config);
+
+        expect(result).toEqual([
+            { name: "sm", min: { value: 1, unit: "rem" }, max: { value: 2, unit: "rem" } },
+            { name: "md", min: { value: 1.5, unit: "rem" }, max: { value: 3, unit: "rem" } },
+            { name: "lg", min: { value: 2, unit: "rem" }, max: { value: 4, unit: "rem" } },
+        ]);
+    });
+
+    it('appends pair steps after named steps when pairs is "adjacent"', () => {
+        const config: MultiplierScaleConfig = {
+            mode: "multipliers",
+            base: remBase(1, 2),
+            multipliers: { sm: 1, md: 1.5, lg: 2 },
+            pairs: "adjacent",
+        };
+
+        const result = calculateScale(config);
+
+        expect(result).toHaveLength(5);
+        expect(result.map((step) => step.name)).toEqual(["sm", "md", "lg", "sm-md", "md-lg"]);
+    });
+
+    it("uses from.min and to.max for each adjacent pair (asymmetric growth)", () => {
+        const config: MultiplierScaleConfig = {
+            mode: "multipliers",
+            base: remBase(1, 2),
+            multipliers: { sm: 1, lg: 2 },
+            pairs: "adjacent",
+        };
+
+        const result = calculateScale(config);
+        const pair = result.find((step) => step.name === "sm-lg");
+
+        expect(pair).toEqual({
+            name: "sm-lg",
+            min: { value: 1, unit: "rem" }, // base.min × multipliers.sm
+            max: { value: 4, unit: "rem" }, // base.max × multipliers.lg
+        });
+    });
+
+    it("emits no pair steps when pairs is omitted", () => {
+        const config: MultiplierScaleConfig = {
+            mode: "multipliers",
+            base: remBase(1, 2),
+            multipliers: { sm: 1, md: 1.5, lg: 2 },
+        };
+
+        const result = calculateScale(config);
+
+        expect(result).toHaveLength(3);
+    });
+
+    it("emits exactly the listed pairs when pairs is a string array", () => {
+        const config: MultiplierScaleConfig = {
+            mode: "multipliers",
+            base: remBase(1, 2),
+            multipliers: { sm: 1, md: 1.5, lg: 2, xl: 3 },
+            pairs: ["sm-xl", "md-lg"],
+        };
+
+        const result = calculateScale(config);
+
+        const pairSteps = result.filter((step) => step.name.includes("-"));
+        expect(pairSteps.map((step) => step.name)).toEqual(["sm-xl", "md-lg"]);
+    });
+
+    it("does not include adjacent pairs when an explicit list is provided", () => {
+        const config: MultiplierScaleConfig = {
+            mode: "multipliers",
+            base: remBase(1, 2),
+            multipliers: { sm: 1, md: 1.5, lg: 2 },
+            pairs: ["sm-lg"],
+        };
+
+        const result = calculateScale(config);
+
+        expect(result.map((step) => step.name)).toEqual(["sm", "md", "lg", "sm-lg"]);
+    });
+});
+
+describe("calculateScale - rounding", () => {
+    it("rounds to 4 decimal places", () => {
+        const config: ExponentialScaleConfig = {
+            mode: "exponential",
+            base: remBase(1, 1),
+            ratio: { min: 1.333, max: 1.333 },
+            steps: { negative: 0, positive: 3 },
+        };
+
+        const result = calculateScale(config);
+
+        // 1.333 ** 3 = 2.368593037 → rounded to 2.3686
+        expect(result[3]?.min.value).toBe(2.3686);
+    });
+});

--- a/packages/core/tests/scale-pipeline.test.ts
+++ b/packages/core/tests/scale-pipeline.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+import { resolveTokens } from "../src/shared/resolve-tokens.js";
+import type { ResolvedToken } from "../src/types/resolve.js";
+import type { TokenGroup, TokenTree } from "../src/types/tokens.js";
+
+function scaleAuthoringGroup(scale: unknown): TokenGroup {
+    return { $extensions: { "sh.sugarcube": { scale } } } as TokenGroup;
+}
+
+const buildTree = (
+    tokens: TokenTree["tokens"],
+    options: { sourcePath?: string; context?: string } = {}
+): TokenTree => ({
+    sourcePath: options.sourcePath ?? "test.json",
+    ...(options.context && { context: options.context }),
+    tokens,
+});
+
+const exponentialScale = {
+    mode: "exponential",
+    base: {
+        min: { value: 1, unit: "rem" },
+        max: { value: 1.125, unit: "rem" },
+    },
+    ratio: { min: 1.2, max: 1.25 },
+    steps: { negative: 1, positive: 2 },
+} as const;
+
+const multipliersScale = {
+    mode: "multipliers",
+    base: {
+        min: { value: 0.875, unit: "rem" },
+        max: { value: 1, unit: "rem" },
+    },
+    multipliers: { sm: 1, md: 1.5 },
+} as const;
+
+describe("scale extension - pipeline integration", () => {
+    it("materializes virtual tokens for an exponential scale", () => {
+        const trees = [
+            buildTree({
+                size: {
+                    step: scaleAuthoringGroup(exponentialScale),
+                },
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree).toHaveLength(0);
+        expect(result.errors.flatten).toHaveLength(0);
+        expect(result.errors.validation).toHaveLength(0);
+
+        const expectedNames = ["size.step.-1", "size.step.0", "size.step.1", "size.step.2"];
+        for (const name of expectedNames) {
+            expect(result.resolved[name]).toBeDefined();
+            const token = result.resolved[name] as ResolvedToken;
+            expect(token.$type).toBe("dimension");
+        }
+    });
+
+    it("materializes virtual tokens for a multiplier scale", () => {
+        const trees = [
+            buildTree({
+                space: scaleAuthoringGroup(multipliersScale),
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree).toHaveLength(0);
+        expect(result.resolved["space.sm"]).toBeDefined();
+        expect(result.resolved["space.md"]).toBeDefined();
+    });
+
+    it('emits adjacent pair tokens when pairs is "adjacent"', () => {
+        const trees = [
+            buildTree({
+                space: scaleAuthoringGroup({ ...multipliersScale, pairs: "adjacent" }),
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree).toHaveLength(0);
+        expect(result.resolved["space.sm-md"]).toBeDefined();
+    });
+
+    it("emits exactly the listed pair tokens when pairs is an explicit list", () => {
+        const trees = [
+            buildTree({
+                space: scaleAuthoringGroup({
+                    ...multipliersScale,
+                    multipliers: { sm: 1, md: 1.5, lg: 2 },
+                    pairs: ["sm-lg"],
+                }),
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree).toHaveLength(0);
+        expect(result.resolved["space.sm-lg"]).toBeDefined();
+        expect(result.resolved["space.sm-md"]).toBeUndefined();
+        expect(result.resolved["space.md-lg"]).toBeUndefined();
+    });
+
+    it("resolves references from another tree to a scale-generated token", () => {
+        const trees = [
+            buildTree(
+                {
+                    size: {
+                        step: scaleAuthoringGroup(exponentialScale),
+                    },
+                },
+                { sourcePath: "size.json" }
+            ),
+            buildTree(
+                {
+                    text: {
+                        body: {
+                            $type: "dimension",
+                            $value: "{size.step.0}",
+                        },
+                    },
+                },
+                { sourcePath: "typography.json" }
+            ),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.resolution).toHaveLength(0);
+        const body = result.resolved["text.body"] as ResolvedToken;
+        expect(body.$resolvedValue).toEqual({ value: 1.125, unit: "rem" });
+    });
+
+    it("preserves sibling tokens authored alongside a scale group", () => {
+        const trees = [
+            buildTree({
+                size: {
+                    step: scaleAuthoringGroup(exponentialScale),
+                    "h1-custom": {
+                        $type: "dimension",
+                        $value: { value: 3, unit: "rem" },
+                    },
+                },
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree).toHaveLength(0);
+        expect(result.resolved["size.h1-custom"]).toBeDefined();
+        expect(result.resolved["size.step.0"]).toBeDefined();
+    });
+
+    it("does not overwrite an authored child that collides with a generated step name", () => {
+        const trees = [
+            buildTree({
+                size: {
+                    step: {
+                        ...scaleAuthoringGroup(exponentialScale),
+                        "0": {
+                            $type: "dimension",
+                            $value: { value: 99, unit: "rem" },
+                        },
+                    } as TokenGroup,
+                },
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        const token = result.resolved["size.step.0"] as ResolvedToken;
+        expect(token.$resolvedValue).toEqual({ value: 99, unit: "rem" });
+    });
+});
+
+describe("scale extension - validation errors", () => {
+    it("surfaces a scale validation error via expandTree errors", () => {
+        const trees = [
+            buildTree({
+                size: {
+                    step: scaleAuthoringGroup({
+                        mode: "exponential",
+                        base: {
+                            min: { value: 1, unit: "rem" },
+                            max: { value: 1.125, unit: "rem" },
+                        },
+                        ratio: { min: 1, max: 1 }, // both <= 1
+                        steps: { negative: 1, positive: 2 },
+                    }),
+                },
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree.length).toBeGreaterThan(0);
+        const ratioErrors = result.errors.expandTree.filter((e) => e.path.endsWith(".ratio.min"));
+        expect(ratioErrors).toHaveLength(1);
+    });
+
+    it("does not materialize tokens when the recipe is invalid", () => {
+        const trees = [
+            buildTree({
+                size: {
+                    step: scaleAuthoringGroup({
+                        mode: "exponential", // missing base, ratio, steps
+                    }),
+                },
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree.length).toBeGreaterThan(0);
+        expect(result.resolved["size.step.0"]).toBeUndefined();
+    });
+});
+
+describe("scale extension - regression: existing pipeline behavior", () => {
+    it("leaves trees without scale extensions untouched", () => {
+        const trees = [
+            buildTree({
+                color: {
+                    $type: "color",
+                    primary: { $value: "#0066cc" },
+                },
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree).toHaveLength(0);
+        expect(result.resolved["color.primary"]).toBeDefined();
+    });
+
+    it("still resolves $ref to authored tokens alongside scale expansion in the same tree", () => {
+        // $ref is JSON Pointer and resolves before scale materializes — it
+        // can only target authored tokens. Curly-brace references can target
+        // scale-generated tokens (covered by the cross-tree test above).
+        const trees = [
+            buildTree({
+                color: {
+                    $type: "color",
+                    blue: { $value: "#0066cc" },
+                },
+                button: {
+                    background: { $ref: "#/color/blue" },
+                },
+                size: {
+                    step: scaleAuthoringGroup(exponentialScale),
+                },
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree).toHaveLength(0);
+        expect(result.resolved["button.background"]).toBeDefined();
+        expect(result.resolved["size.step.0"]).toBeDefined();
+    });
+});

--- a/packages/core/tests/scale-pipeline.test.ts
+++ b/packages/core/tests/scale-pipeline.test.ts
@@ -86,6 +86,44 @@ describe("scale extension - pipeline integration", () => {
         expect(result.resolved["space.sm-md"]).toBeDefined();
     });
 
+    it("lets a hand-authored token shadow a generated one with the same name", () => {
+        const trees = [
+            buildTree({
+                space: {
+                    ...scaleAuthoringGroup(multipliersScale),
+                    md: {
+                        $type: "dimension",
+                        $value: { value: 10, unit: "rem" },
+                        $extensions: {
+                            "sh.sugarcube": {
+                                fluid: {
+                                    min: { value: 5, unit: "rem" },
+                                    max: { value: 10, unit: "rem" },
+                                },
+                            },
+                        },
+                    },
+                } as TokenGroup,
+            }),
+        ];
+
+        const result = resolveTokens(trees);
+
+        expect(result.errors.expandTree).toHaveLength(0);
+        const md = result.resolved["space.md"] as ResolvedToken;
+        expect(md.$value).toEqual({ value: 10, unit: "rem" });
+        // The hand-authored fluid range survived — not the recipe-generated one
+        // (which would have been 1.3125rem → 1.5rem from base × 1.5).
+        const fluid = (md.$extensions as { "sh.sugarcube": { fluid: unknown } })["sh.sugarcube"]
+            .fluid as { min: unknown; max: unknown };
+        expect(fluid).toEqual({
+            min: { value: 5, unit: "rem" },
+            max: { value: 10, unit: "rem" },
+        });
+        // Sibling generated tokens are unaffected.
+        expect(result.resolved["space.sm"]).toBeDefined();
+    });
+
     it("emits exactly the listed pair tokens when pairs is an explicit list", () => {
         const trees = [
             buildTree({

--- a/packages/core/tests/scale-validator.test.ts
+++ b/packages/core/tests/scale-validator.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { validateScaleExtension } from "../src/shared/validators/scale.js";
+import type { TokenSource } from "../src/types/tokens.js";
+
+const source: TokenSource = { sourcePath: "test.json" };
+const path = "size.step.$extensions.sh.sugarcube.scale";
+
+const validExponential = {
+    mode: "exponential",
+    base: {
+        min: { value: 1, unit: "rem" },
+        max: { value: 1.125, unit: "rem" },
+    },
+    ratio: { min: 1.2, max: 1.25 },
+    steps: { negative: 2, positive: 5 },
+};
+
+const validMultipliers = {
+    mode: "multipliers",
+    base: {
+        min: { value: 0.875, unit: "rem" },
+        max: { value: 1, unit: "rem" },
+    },
+    multipliers: { sm: 1, md: 1.5, lg: 2 },
+};
+
+describe("validateScaleExtension - well-formed configs", () => {
+    it("returns no errors for a valid exponential config", () => {
+        expect(validateScaleExtension(validExponential, path, source)).toEqual([]);
+    });
+
+    it('returns no errors for a valid multipliers config with pairs: "adjacent"', () => {
+        expect(
+            validateScaleExtension({ ...validMultipliers, pairs: "adjacent" }, path, source)
+        ).toEqual([]);
+    });
+
+    it("returns no errors for a valid multipliers config with an explicit pair list", () => {
+        expect(
+            validateScaleExtension({ ...validMultipliers, pairs: ["sm-lg"] }, path, source)
+        ).toEqual([]);
+    });
+
+    it("returns no errors for a valid multipliers config (without pairs)", () => {
+        expect(validateScaleExtension(validMultipliers, path, source)).toEqual([]);
+    });
+});
+
+describe("validateScaleExtension - top-level shape", () => {
+    it("rejects non-object input", () => {
+        const errors = validateScaleExtension("nope", path, source);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]?.path).toBe(path);
+    });
+
+    it("requires `mode`", () => {
+        const { mode: _omit, ...rest } = validExponential;
+        const errors = validateScaleExtension(rest, path, source);
+        expect(errors.some((e) => e.path === `${path}.mode`)).toBe(true);
+    });
+
+    it("rejects unknown `mode` values", () => {
+        const errors = validateScaleExtension(
+            { ...validExponential, mode: "linear" },
+            path,
+            source
+        );
+        expect(errors.some((e) => e.path === `${path}.mode`)).toBe(true);
+    });
+
+    it("requires `base`", () => {
+        const { base: _omit, ...rest } = validExponential;
+        const errors = validateScaleExtension(rest, path, source);
+        expect(errors.some((e) => e.path === `${path}.base`)).toBe(true);
+    });
+});
+
+describe("validateScaleExtension - base rules", () => {
+    it("rejects base.min with bad unit", () => {
+        const config = {
+            ...validExponential,
+            base: {
+                min: { value: 1, unit: "em" },
+                max: { value: 1, unit: "rem" },
+            },
+        };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.base.min.unit`)).toBe(true);
+    });
+
+    it("rejects non-numeric dimension value", () => {
+        const config = {
+            ...validExponential,
+            base: {
+                min: { value: "1rem", unit: "rem" },
+                max: { value: 1, unit: "rem" },
+            },
+        };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.base.min.value`)).toBe(true);
+    });
+});
+
+describe("validateScaleExtension - exponential-only fields", () => {
+    it("requires `ratio`", () => {
+        const { ratio: _omit, ...rest } = validExponential;
+        const errors = validateScaleExtension(rest, path, source);
+        expect(errors.some((e) => e.path === `${path}.ratio`)).toBe(true);
+    });
+
+    it("requires `steps`", () => {
+        const { steps: _omit, ...rest } = validExponential;
+        const errors = validateScaleExtension(rest, path, source);
+        expect(errors.some((e) => e.path === `${path}.steps`)).toBe(true);
+    });
+
+    it("rejects ratio <= 1", () => {
+        const config = { ...validExponential, ratio: { min: 1, max: 1.25 } };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.ratio.min`)).toBe(true);
+    });
+
+    it("rejects negative ratio", () => {
+        const config = { ...validExponential, ratio: { min: 1.2, max: -1 } };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.ratio.max`)).toBe(true);
+    });
+
+    it("rejects non-integer step counts", () => {
+        const config = { ...validExponential, steps: { negative: 2, positive: 1.5 } };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.steps.positive`)).toBe(true);
+    });
+
+    it("rejects negative step counts", () => {
+        const config = { ...validExponential, steps: { negative: -1, positive: 5 } };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.steps.negative`)).toBe(true);
+    });
+});
+
+describe("validateScaleExtension - multipliers-only fields", () => {
+    it("requires `multipliers`", () => {
+        const { multipliers: _omit, ...rest } = validMultipliers;
+        const errors = validateScaleExtension(rest, path, source);
+        expect(errors.some((e) => e.path === `${path}.multipliers`)).toBe(true);
+    });
+
+    it("rejects empty multipliers object", () => {
+        const config = { ...validMultipliers, multipliers: {} };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.multipliers`)).toBe(true);
+    });
+
+    it("rejects non-numeric multiplier value", () => {
+        const config = { ...validMultipliers, multipliers: { sm: 1, md: "1.5x" } };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.multipliers.md`)).toBe(true);
+    });
+
+    it('rejects pairs values that are neither "adjacent" nor an array', () => {
+        const config = { ...validMultipliers, pairs: "yes" };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.pairs`)).toBe(true);
+    });
+
+    it("rejects pair entries that don't contain a hyphen", () => {
+        const config = { ...validMultipliers, pairs: ["sm_lg"] };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.pairs[0]`)).toBe(true);
+    });
+
+    it("rejects pair entries that reference unknown multipliers", () => {
+        const config = { ...validMultipliers, pairs: ["sm-xxl"] };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.pairs[0]`)).toBe(true);
+    });
+});
+
+describe("validateScaleExtension - reference rejection", () => {
+    it("rejects a reference inside a nested dimension value", () => {
+        const config = {
+            ...validExponential,
+            base: {
+                min: { value: "{size.base}", unit: "rem" },
+                max: { value: 1.125, unit: "rem" },
+            },
+        };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.base.min.value`)).toBe(true);
+    });
+
+    it("rejects a reference inside a multiplier value", () => {
+        const config = {
+            ...validMultipliers,
+            multipliers: { sm: "{multiplier.small}", md: 1.5 },
+        };
+        const errors = validateScaleExtension(config, path, source);
+        expect(errors.some((e) => e.path === `${path}.multipliers.sm`)).toBe(true);
+    });
+
+    it("does not flag string values that aren't references (e.g. mode)", () => {
+        const errors = validateScaleExtension(validExponential, path, source);
+        expect(errors).toEqual([]);
+    });
+});

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -180,6 +180,7 @@ function createSugarcubeContext(): SugarcubePluginContext {
 
         const allErrors = [
             ...loaded.errors,
+            ...resolveResult.errors.expandTree,
             ...resolveResult.errors.flatten,
             ...resolveResult.errors.validation,
             ...resolveResult.errors.resolution,


### PR DESCRIPTION
Addresses #55.

Adds an `sh.sugarcube.scale` extension that lets a group node declare scale recipes. The API is very similar to how utopia.fyi might structure things.

Supports two modes:

- exponential: base × ratio^n with separate min/max ratios
- multipliers: named multipliers, optional adjacent or explicit pairs

The viewport range is read from the global `transforms.fluid` config.