### PR TITLE
ci: npm hardening

### DIFF
--- a/.changeset/silent-shrimps-stay.md
+++ b/.changeset/silent-shrimps-stay.md
@@ -1,0 +1,7 @@
+---
+"@sugarcube-sh/core": patch
+"@sugarcube-sh/vite": patch
+"@sugarcube-sh/cli": patch
+---
+
+Harden some npm practices. Make minimum release age strict. Set provenance to true (which mirrors the actual state of things already (provenance: false was misleading))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.12",
     "publishConfig": {
         "access": "public",
-        "provenance": false
+        "provenance": true
     },
     "description": "CLI for sugarcube",
     "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
     "version": "0.2.6",
     "publishConfig": {
         "access": "public",
-        "provenance": false
+        "provenance": true
     },
     "description": "Core functionality for sugarcube",
     "license": "MIT",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -4,7 +4,7 @@
     "type": "module",
     "publishConfig": {
         "access": "public",
-        "provenance": false
+        "provenance": true
     },
     "description": "Vite plugin for sugarcube",
     "license": "MIT",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - packages/*
 
 trustPolicy: no-downgrade
+minimumReleaseAgeStrict: true
 
 onlyBuiltDependencies:
   - '@biomejs/biome'


### PR DESCRIPTION
Trusted publishing was already setup in npm so `provenance: false` was misleading. Updated it to accurately reflect reality.

Add strictness to pnpm minimum release age.