### PR TITLE
Add padding to accordion summary element

### DIFF
--- a/apps/www/registry/components/accordion/css/accordion.css
+++ b/apps/www/registry/components/accordion/css/accordion.css
@@ -16,6 +16,7 @@
     line-height: var(--leading-tight);
     font-weight: var(--font-weight-medium);
     cursor: pointer;
+    padding-inline-end: var(--space-lg, 2.5em);
 }
 
 .accordion details[open] summary {


### PR DESCRIPTION
Without the padding, the summary text clashes with the chevron background-image on narrow accordion widths