### PR TITLE
fix: maintain numeric order for positive/negative integer token keys

### DIFF
--- a/.changeset/orange-jars-cross.md
+++ b/.changeset/orange-jars-cross.md
@@ -1,0 +1,5 @@
+---
+"@sugarcube-sh/core": patch
+---
+
+fix: maintain numeric order for positive/negative integer token keys

--- a/packages/core/src/shared/pipeline/flatten.ts
+++ b/packages/core/src/shared/pipeline/flatten.ts
@@ -89,7 +89,7 @@ function flattenTree(
             .sort((a, b) => {
                 // Object.keys() reorders integer-index keys ("0","1","2") before string keys ("-2","-1").
                 // Resort only numeric keys to handle this discrepancy without affecting other ordering.
-                if (!isNaN(Number(a)) && !isNaN(Number(b))) {
+                if (!Number.isNaN(Number(a)) && !Number.isNaN(Number(b))) {
                     return Number(a) - Number(b);
                 }
                 return 0;

--- a/packages/core/src/shared/pipeline/flatten.ts
+++ b/packages/core/src/shared/pipeline/flatten.ts
@@ -84,7 +84,16 @@ function flattenTree(
 
         // Filter out metadata properties (those starting with $), but allow $root
         // which is a reserved token name per DTCG 2025.10 spec
-        const keys = Object.keys(node).filter((key) => !key.startsWith("$") || key === "$root");
+        const keys = Object.keys(node)
+            .filter((key) => !key.startsWith("$") || key === "$root")
+            .sort((a, b) => {
+                // Object.keys() reorders integer-index keys ("0","1","2") before string keys ("-2","-1").
+                // Resort only numeric keys to handle this discrepancy without affecting other ordering.
+                if (!isNaN(Number(a)) && !isNaN(Number(b))) {
+                    return Number(a) - Number(b);
+                }
+                return 0;
+            });
 
         const currentType = node.$type || inheritedType;
 

--- a/packages/core/tests/flatten.test.ts
+++ b/packages/core/tests/flatten.test.ts
@@ -464,4 +464,44 @@ describe("flatten", () => {
             expect(ctx.warnings).toHaveLength(0);
         });
     });
+
+    describe("key ordering", () => {
+        it("preserves authored order for both string and numeric (including negative) keys", () => {
+            const { tokens } = flatten([
+                buildTree({
+                    step: {
+                        $type: "dimension",
+                        "-2": { $value: "2px" },
+                        "-1": { $value: "4px" },
+                        "0": { $value: "8px" },
+                        "1": { $value: "16px" },
+                        "2": { $value: "32px" },
+                    },
+                    tshirt: {
+                        $type: "dimension",
+                        "xs": { $value: "2px" },
+                        "sm": { $value: "4px" },
+                        "md": { $value: "8px" },
+                        "lg": { $value: "16px" },
+                        "xl": { $value: "32px" },
+                    },
+                }),
+            ]);
+
+            expect(Object.keys(tokens.tokens)).toEqual([
+                "step",
+                "step.-2",
+                "step.-1",
+                "step.0",
+                "step.1",
+                "step.2",
+                "tshirt",
+                "tshirt.xs",
+                "tshirt.sm",
+                "tshirt.md",
+                "tshirt.lg",
+                "tshirt.xl",
+            ]);
+        });
+    });
 });


### PR DESCRIPTION
Addresses #107

I'm new to the codebase so if you foresee any issues with this change let me know and I'm happy to make changes. Also happy to close if you have a different way you'd like to address it or if you don't think it's worth the complexity of adding a sort to the processing pipeline.