### PR TITLE
fix: root variable name leak

### DIFF
--- a/.changeset/fix-root-variablename-leak.md
+++ b/.changeset/fix-root-variablename-leak.md
@@ -1,0 +1,9 @@
+---
+"@sugarcube-sh/core": patch
+---
+
+fix: strip `$root` from CSS variable names when a `variableName` callback is set
+
+A `$root` token's path (e.g. `blue.$root`) is meant to emit under its group path (`--blue`). The `$root` segment is a reference-only disambiguator and must never reach an identifier. The default and `prefix` naming paths already stripped it, but a custom `variableName` callback received the raw path including `.$root`, producing names like `--blue_$root`. That isn't a valid CSS custom property (`$` is not a valid identifier character), so browsers drop the declaration and the token's value silently disappears.
+
+The strip now happens in the resolver, before the `variableName` callback runs, so every naming route - default, `prefix`, and `variableName` (including Studio, which builds names through the same resolver) - honours the invariant. Alias references keep resolving because the lookup is still the full `$path`.

--- a/packages/core/src/shared/format-css-var-name.ts
+++ b/packages/core/src/shared/format-css-var-name.ts
@@ -22,9 +22,12 @@
  */
 const ROOT_SUFFIX = ".$root";
 
+export function stripRootSuffix(path: string): string {
+    return path.endsWith(ROOT_SUFFIX) ? path.slice(0, -ROOT_SUFFIX.length) : path;
+}
+
 export function formatCSSVarName(path: string): string {
-    const normalized = path.endsWith(ROOT_SUFFIX) ? path.slice(0, -ROOT_SUFFIX.length) : path;
-    return normalized
+    return stripRootSuffix(path)
         .split(".")
         .map((segment) => segment.trim().replace(/\s+/g, "-"))
         .join("-");

--- a/packages/core/src/shared/resolve-variable-name.ts
+++ b/packages/core/src/shared/resolve-variable-name.ts
@@ -1,5 +1,5 @@
 import type { VariableNameFn } from "../types/config.js";
-import { formatCSSVarName } from "./format-css-var-name.js";
+import { formatCSSVarName, stripRootSuffix } from "./format-css-var-name.js";
 
 /** Subset of config needed to resolve a variable name — works against both user and internal configs. */
 type VariablesNameConfig = {
@@ -29,7 +29,7 @@ export function createVariableNameResolver(
     variables: VariablesNameConfig | undefined
 ): (path: string) => string {
     const variableName = variables?.variableName;
-    if (variableName) return variableName;
+    if (variableName) return (path: string) => variableName(stripRootSuffix(path));
 
     const prefix = variables?.prefix;
     if (prefix) return (path: string) => `${prefix}-${formatCSSVarName(path)}`;

--- a/packages/core/tests/assign-css-names.test.ts
+++ b/packages/core/tests/assign-css-names.test.ts
@@ -153,4 +153,33 @@ describe("convert", () => {
         const token = result.default?.["color.primary"] as RenderableToken<TokenType>;
         expect(token.$names.css).toBe("only-color-primary");
     });
+
+    describe("$root tokens", () => {
+        const rootToken: NormalizedTokens = {
+            default: {
+                "blue.$root": createResolvedToken({
+                    $path: "blue.$root",
+                    $originalPath: "blue.$root",
+                }),
+            },
+        };
+
+        it("strips $root on the default path", () => {
+            const result = assignCSSNames(rootToken, fillDefaults({}));
+
+            const token = result.default?.["blue.$root"] as RenderableToken<TokenType>;
+            expect(token.$names.css).toBe("blue");
+        });
+
+        it("strips $root even when variableName is set", () => {
+            const result = assignCSSNames(
+                rootToken,
+                fillDefaults({ variables: { variableName: (path) => path.replaceAll(".", "_") } })
+            );
+
+            const token = result.default?.["blue.$root"] as RenderableToken<TokenType>;
+            expect(token.$names.css).not.toContain("$root");
+            expect(token.$names.css).toBe("blue");
+        });
+    });
 });


### PR DESCRIPTION
Discovered a bug whereby `$root` tokens where not being stripped when `config.variables.variableName` callback in place.