### PR TITLE
feat: content config

### DIFF
--- a/.changeset/eight-pears-occur.md
+++ b/.changeset/eight-pears-occur.md
@@ -1,0 +1,15 @@
+---
+"@sugarcube-sh/core": patch
+"@sugarcube-sh/cli": patch
+---
+
+Add a `content` config option that tells the CLI which source files to scan for token and utility usage. Until now, `generate` and `lint` only ever looked at the directory you ran them from and everything below it, so projects that keep sugarcube installed apart from their markup had no way to scan it. Set `content` to a list of globs and both commands read from wherever your files actually live:
+
+```ts
+export default defineConfig({
+  content: ["./**/*.{js,ts}", "../../templates/**/*.html"]
+});
+```
+
+The globs are resolved relative to your config file rather than your working directory, so a config that sits in a subfolder can still reach files above it with ../, and you keep running sugarcube from the same place as before. generate picks up utility class names from your markup and lint picks up var() references from your CSS, each ignoring the file types it doesn't care about, so listing a folder broadly is fine. Prefix a glob with ! to exclude paths. Watch mode follows content too, regenerating when those files change. When content is omitted, scanning behaves exactly as before, so this is fully backward compatible. Only the CLI reads this option; the Vite plugin discovers usage through the bundler's module graph.
+

--- a/apps/www/src/content/docs/docs/configuration.mdx
+++ b/apps/www/src/content/docs/docs/configuration.mdx
@@ -25,6 +25,29 @@ export default defineConfig({});
 
 Sugarcube can generate utility classes from your design tokens. Utilities are configured in the `utilities.classes` key of your config file. See [CSS Utilities](/docs/utilities) for full details.
 
+## Telling sugarcube where your markup lives
+
+When the CLI generates utility classes, it scans your source files to see which classes you actually use and generates only those. By default it looks in the directory you run the command from and everything beneath it. The `lint` command works the same way, reading your CSS and markup to find `var()` references.
+
+Not every project keeps sugarcube installed next to the files it needs to scan. Sometimes your build tooling sits in one folder while your templates or components live in another, above or outside it, and the default scan never sees them. The `content` option points sugarcube at wherever your markup actually lives.
+
+```ts title="sugarcube.config.ts" ins={4-7}
+import { defineConfig } from "@sugarcube-sh/cli";
+
+export default defineConfig({
+  content: [
+    "./**/*.{js,ts}",
+    "../../templates/**/*.html"
+  ]
+});
+```
+
+The globs in `content` are resolved relative to your config file rather than your working directory, so a config that lives in a subfolder can still reach files above it with `../`, and you keep running sugarcube from the same place as before. Generation reads your markup for class names and `lint` reads your CSS for variable references, so it's fine to list a folder broadly and let each command pick up only the file types it understands. To leave something out, prefix its glob with `!`, for example `"!../../templates/**/vendor/**"`.
+
+<SiteAside type="note">
+    The `content` option applies to the CLI only. The Vite plugin discovers class and variable usage through the bundler's module graph, so it doesn't read this option.
+</SiteAside>
+
 ## Changing where CSS files are written
 
 <SiteAside type="note">

--- a/apps/www/src/content/docs/docs/reference/configuration-schema.mdx
+++ b/apps/www/src/content/docs/docs/reference/configuration-schema.mdx
@@ -362,6 +362,33 @@ utilities: {
 }
 ```
 
+## content
+
+**Type:** `string[]`
+**Optional**
+
+Globs pointing at the source files sugarcube scans to learn how your tokens and utilities are used. Utility generation reads them to find which utility classes appear in your markup and generates only those, while `lint` reads them to find `var()` references to check. Each command looks only at the file types it understands, so you can list a directory broadly and let sugarcube sort out what's relevant.
+
+The globs are resolved relative to your config file, not the directory you run the command from. This lets a config that sits in a subfolder reach files elsewhere in the project, which matters when sugarcube isn't installed next to the markup it needs to scan.
+
+```ts
+import { defineConfig } from "@sugarcube-sh/cli";
+
+export default defineConfig({
+  content: [
+    "./**/*.{js,ts}",
+    "../../templates/**/*.html",
+    "!../../templates/**/vendor/**"
+  ]
+});
+```
+
+When omitted, sugarcube scans the working directory and everything beneath it. Prefix a glob with `!` to exclude matching paths.
+
+<SiteAside type="note">
+    This option applies to the CLI only. The Vite plugin finds usage through the bundler's module graph and ignores it.
+</SiteAside>
+
 ## components
 
 **Type:** `string`

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -228,7 +228,7 @@ async function generateSugarcubeUtilities(
 
     const generator = await createGenerator(generatorOptions);
 
-    const files = await getMarkupFiles();
+    const files = await getMarkupFiles(config.content);
     if (files.length === 0 && safelist.length === 0) return [];
 
     const sources = await readMarkupSources(files);

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -27,7 +27,7 @@ async function runScan(
     config: InternalConfig,
     files: string[],
     ignorePrefixes: string[],
-    resolver: SyntaxResolver
+    resolver: SyntaxResolver,
 ): Promise<ScanOutput> {
     const declared = await getGeneratedVarNames(config);
 
@@ -77,12 +77,12 @@ export const lint = new Command()
     .argument("[paths...]", "Globs of files to scan (default: project CSS and components)")
     .option(
         "--ignore <prefixes>",
-        'Comma-separated var-name prefixes to ignore (e.g. "--sl-,--radix-,--ec-")'
+        'Comma-separated var-name prefixes to ignore (e.g. "--sl-,--radix-,--ec-")',
     )
     .addOption(
         new Option("--fallback <level>", "How to treat references that have a fallback")
             .choices(["error", "warn", "off"])
-            .default("warn")
+            .default("warn"),
     )
     .option("--json", "Output machine-readable JSON")
     .action(async (paths: string[], options: LintOptions) => {
@@ -94,22 +94,20 @@ export const lint = new Command()
                 ({ config } = await loadInternalConfig());
             } catch {
                 throw new CLIError(
-                    "No sugarcube config found. Run `sugarcube lint` from a project with a sugarcube config."
+                    "No sugarcube config found. Run `sugarcube lint` from a project with a sugarcube config.",
                 );
             }
 
             const resolver = createSyntaxResolver();
 
             const generatedOutput = resolve(process.cwd(), config.variables.path);
-            const files = await glob(
-                paths.length > 0 ? paths : [buildExtensionGlob(resolver.extensions())],
-                {
-                    cwd: process.cwd(),
-                    absolute: true,
-                    caseSensitiveMatch: false,
-                    ignore: [...IGNORED_DIR_GLOBS, generatedOutput],
-                }
-            );
+            const defaultPatterns = config.content ?? [buildExtensionGlob(resolver.extensions())];
+            const files = await glob(paths.length > 0 ? paths : defaultPatterns, {
+                cwd: process.cwd(),
+                absolute: true,
+                caseSensitiveMatch: false,
+                ignore: [...IGNORED_DIR_GLOBS, generatedOutput],
+            });
             const ignorePrefixes = parseIgnore(options.ignore);
             const fallbackLevel = options.fallback ?? "warn";
             const fallbackIsError = fallbackLevel === "error";
@@ -127,7 +125,7 @@ export const lint = new Command()
                 config,
                 files,
                 ignorePrefixes,
-                resolver
+                resolver,
             );
             const showFallback = fallbackLevel !== "off";
             const reportFallback = fallbackIsError ? log.error : log.warn;
@@ -138,7 +136,7 @@ export const lint = new Command()
                         color.bold(`References without fallback (${broken.length})`),
                         "",
                         ...formatGroupedRefs(broken),
-                    ].join("\n")
+                    ].join("\n"),
                 );
             }
 
@@ -148,7 +146,7 @@ export const lint = new Command()
                         color.bold(`References with fallback (${fallback.length})`),
                         "",
                         ...formatGroupedRefs(fallback),
-                    ].join("\n")
+                    ].join("\n"),
                 );
             }
 

--- a/packages/cli/src/lint/scan-css.ts
+++ b/packages/cli/src/lint/scan-css.ts
@@ -63,7 +63,7 @@ export interface UndeclaredReport {
 export function findUndeclared(
     used: VarRef[],
     declared: Set<string>,
-    ignorePrefixes: string[]
+    ignorePrefixes: string[],
 ): UndeclaredReport {
     const seen = new Set<string>();
     const broken: VarRef[] = [];

--- a/packages/cli/src/scan-markup.ts
+++ b/packages/cli/src/scan-markup.ts
@@ -1,7 +1,12 @@
 import { readFile } from "node:fs/promises";
+import { extname } from "pathe";
 import { glob } from "tinyglobby";
 import { CLIError } from "./cli-error.js";
-import { MARKUP_GLOB_PATTERN, MARKUP_IGNORE_PATTERNS } from "./constants/markup.js";
+import {
+    MARKUP_EXTENSIONS,
+    MARKUP_GLOB_PATTERN,
+    MARKUP_IGNORE_PATTERNS,
+} from "./constants/markup.js";
 
 // Safety limits to prevent OOM crashes
 // Can't just search up etc because CLI has to work with the simplest possible setup
@@ -10,14 +15,22 @@ const MAX_FILES = 10_000;
 const MAX_SIZE_MB = 100;
 const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
 
-export async function getMarkupFiles(): Promise<string[]> {
-    const files = await glob([MARKUP_GLOB_PATTERN], {
+function isMarkupFile(file: string): boolean {
+    return MARKUP_EXTENSIONS.has(extname(file).slice(1).toLowerCase());
+}
+
+export async function getMarkupFiles(content?: string[]): Promise<string[]> {
+    const usingContent = content !== undefined && content.length > 0;
+
+    const matched = await glob(usingContent ? content : [MARKUP_GLOB_PATTERN], {
         ignore: MARKUP_IGNORE_PATTERNS,
         dot: false,
         onlyFiles: true,
-        absolute: false,
+        absolute: usingContent,
         caseSensitiveMatch: false,
     });
+
+    const files = usingContent ? matched.filter(isMarkupFile) : matched;
 
     if (files.length > MAX_FILES) {
         throw new CLIError(

--- a/packages/cli/src/watch/watcher.ts
+++ b/packages/cli/src/watch/watcher.ts
@@ -14,6 +14,24 @@ export type WatcherHandle = {
     close: () => Promise<void>;
 };
 
+const GLOB_MAGIC = /[*?{}[\]!]/;
+
+function globBaseDir(glob: string): string {
+    const staticSegments: string[] = [];
+    for (const segment of glob.split("/")) {
+        if (GLOB_MAGIC.test(segment)) break;
+        staticSegments.push(segment);
+    }
+    return staticSegments.join("/") || "/";
+}
+
+// Derive the directories to watch for markup changes from `content` globs. (Chokidar v5 no longer expands globs)
+export function resolveMarkupWatchTargets(content: string[] | undefined): string[] {
+    if (!content || content.length === 0) return ["."];
+    const dirs = content.filter((glob) => !glob.startsWith("!")).map(globBaseDir);
+    return [...new Set(dirs)];
+}
+
 export async function startWatcher(
     config: InternalConfig,
     callbacks: WatchCallbacks,
@@ -42,7 +60,7 @@ export async function startWatcher(
         },
     });
 
-    const markupWatcher = chokidarWatch(".", {
+    const markupWatcher = chokidarWatch(resolveMarkupWatchTargets(config.content), {
         ignoreInitial: true,
         ignored: (path, stats) => {
             const segments = path.split("/");

--- a/packages/cli/tests/e2e/generate-content.test.ts
+++ b/packages/cli/tests/e2e/generate-content.test.ts
@@ -1,0 +1,62 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execaCommand } from "execa";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CLI_PATH, TEST_TIMEOUT, createPackageJson, createTokens } from "./helpers.js";
+
+describe("generate command: content globs", () => {
+    let testDir: string;
+    let assetsJs: string;
+
+    beforeEach(async () => {
+        testDir = join(tmpdir(), `sugarcube-e2e-content-${Date.now()}`);
+        assetsJs = join(testDir, "assets", "js");
+        await mkdir(assetsJs, { recursive: true });
+        await createPackageJson(assetsJs);
+        await createTokens(assetsJs);
+
+        const libDir = join(testDir, "lib", "app_web");
+        await mkdir(libDir, { recursive: true });
+        await writeFile(join(libDir, "page.heex"), `<div class="text-primary">hi</div>`);
+
+        const config = `
+            export default {
+                resolver: "./design-tokens/tokens.resolver.json",
+                variables: { path: "../css/tokens.css" },
+                utilities: {
+                    path: "../css/utilities.css",
+                    classes: { color: { source: "color.*", prefix: "text" } },
+                },
+                content: ["../../lib/**/*.heex"],
+            };
+        `;
+        await writeFile(join(assetsJs, "sugarcube.config.js"), config);
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it(
+        "generates utilities for classes used in templates above the working directory",
+        { timeout: TEST_TIMEOUT },
+        async () => {
+            const result = await execaCommand(`node ${CLI_PATH} generate`, {
+                cwd: assetsJs,
+                timeout: TEST_TIMEOUT,
+                reject: false,
+            });
+
+            expect(result.exitCode).toBe(0);
+
+            // Output paths are cwd-relative (cwd = assets/js), so `../css` is assets/css.
+            const utilitiesPath = join(testDir, "assets", "css", "utilities.css");
+            expect(existsSync(utilitiesPath)).toBe(true);
+
+            const css = await readFile(utilitiesPath, "utf-8");
+            expect(css).toContain(".text-primary");
+        },
+    );
+});

--- a/packages/cli/tests/e2e/lint-content.test.ts
+++ b/packages/cli/tests/e2e/lint-content.test.ts
@@ -1,0 +1,50 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execaCommand } from "execa";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CLI_PATH, TEST_TIMEOUT, createPackageJson, createTokens } from "./helpers.js";
+
+describe("lint command: content globs", () => {
+    let testDir: string;
+    let assetsJs: string;
+
+    beforeEach(async () => {
+        testDir = join(tmpdir(), `sugarcube-e2e-lint-content-${Date.now()}`);
+        assetsJs = join(testDir, "assets", "js");
+        await mkdir(assetsJs, { recursive: true });
+        await createPackageJson(assetsJs);
+        await createTokens(assetsJs);
+
+        const cssDir = join(testDir, "assets", "css");
+        await mkdir(cssDir, { recursive: true });
+        await writeFile(join(cssDir, "app.css"), `.x { color: var(--not-a-token); }`);
+
+        const config = `
+            export default {
+                resolver: "./design-tokens/tokens.resolver.json",
+                variables: { path: "../css/tokens.css" },
+                content: ["../css/**/*.css"],
+            };
+        `;
+        await writeFile(join(assetsJs, "sugarcube.config.js"), config);
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it(
+        "scans CSS reached via content and reports undeclared var() refs",
+        { timeout: TEST_TIMEOUT },
+        async () => {
+            const result = await execaCommand(`node ${CLI_PATH} lint --json`, {
+                cwd: assetsJs,
+                timeout: TEST_TIMEOUT,
+                reject: false,
+            });
+
+            expect(result.stdout).toContain("--not-a-token");
+        },
+    );
+});

--- a/packages/cli/tests/scan-markup.test.ts
+++ b/packages/cli/tests/scan-markup.test.ts
@@ -1,0 +1,57 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getMarkupFiles } from "../src/scan-markup.js";
+
+describe("getMarkupFiles with content patterns", () => {
+    let base: string;
+    let cwdDir: string;
+    let originalCwd: string;
+
+    beforeEach(async () => {
+        originalCwd = process.cwd();
+        base = join(tmpdir(), `sugarcube-scan-${Date.now()}`);
+        cwdDir = join(base, "assets", "js");
+        const templatesDir = join(base, "lib", "app_web");
+        const vendorDir = join(templatesDir, "vendor");
+        await mkdir(cwdDir, { recursive: true });
+        await mkdir(vendorDir, { recursive: true });
+        await writeFile(join(templatesDir, "page.heex"), `<div class="p-400"></div>`);
+        await writeFile(join(templatesDir, "styles.css"), `.x { color: red; }`);
+        await writeFile(join(vendorDir, "widget.heex"), `<div class="p-800"></div>`);
+        process.chdir(cwdDir);
+    });
+
+    afterEach(async () => {
+        process.chdir(originalCwd);
+        await rm(base, { recursive: true, force: true });
+    });
+
+    it("scans a content glob that points above the working directory", async () => {
+        const pattern = join(base, "lib", "**", "*");
+
+        const files = await getMarkupFiles([pattern]);
+
+        expect(files.some((f) => f.endsWith("page.heex"))).toBe(true);
+    });
+
+    it("filters out non-markup files from a broad content glob", async () => {
+        const pattern = join(base, "lib", "**", "*");
+
+        const files = await getMarkupFiles([pattern]);
+
+        expect(files.some((f) => f.endsWith("page.heex"))).toBe(true);
+        expect(files.some((f) => f.endsWith("styles.css"))).toBe(false);
+    });
+
+    it("excludes files matched by a negation glob", async () => {
+        const include = join(base, "lib", "**", "*.heex");
+        const exclude = `!${join(base, "lib", "**", "vendor", "**")}`;
+
+        const files = await getMarkupFiles([include, exclude]);
+
+        expect(files.some((f) => f.endsWith("page.heex"))).toBe(true);
+        expect(files.some((f) => f.endsWith("widget.heex"))).toBe(false);
+    });
+});

--- a/packages/cli/tests/watcher-targets.test.ts
+++ b/packages/cli/tests/watcher-targets.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveMarkupWatchTargets } from "../src/watch/watcher.js";
+
+describe("resolveMarkupWatchTargets", () => {
+    it("falls back to the working directory when no content is configured", () => {
+        expect(resolveMarkupWatchTargets(undefined)).toEqual(["."]);
+        expect(resolveMarkupWatchTargets([])).toEqual(["."]);
+    });
+
+    it("derives static base dirs from content globs", () => {
+        expect(
+            resolveMarkupWatchTargets(["/root/lib/**/*.heex", "/root/assets/js/**/*.js"]),
+        ).toEqual(["/root/lib", "/root/assets/js"]);
+    });
+
+    it("dedupes base dirs shared by multiple globs", () => {
+        expect(resolveMarkupWatchTargets(["/root/lib/**/*.heex", "/root/lib/**/*.ex"])).toEqual([
+            "/root/lib",
+        ]);
+    });
+
+    it("ignores negation globs — they scope output, not what to watch", () => {
+        expect(
+            resolveMarkupWatchTargets(["/root/lib/**/*.heex", "!/root/lib/**/vendor/**"]),
+        ).toEqual(["/root/lib"]);
+    });
+});

--- a/packages/core/src/node/config/load.ts
+++ b/packages/core/src/node/config/load.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import { createJiti } from "jiti";
-import { resolve } from "pathe";
+import { dirname, resolve } from "pathe";
 import { validateInternalConfig, validateSugarcubeConfig } from "../../shared/config.js";
 import { ErrorMessages } from "../../shared/constants/error-messages.js";
 import type { InternalConfig, SugarcubeConfig } from "../../types/config.js";
@@ -10,6 +10,13 @@ import { fillDefaults } from "./normalize.js";
 
 export function isNoConfigError(error: unknown): boolean {
     return error instanceof Error && error.message === ErrorMessages.CONFIG.NO_CONFIG_OR_RESOLVER();
+}
+
+function resolveContentGlobs(content: string[] | undefined, baseDir: string): string[] | undefined {
+    if (!content) return content;
+    return content.map((glob) =>
+        glob.startsWith("!") ? `!${resolve(baseDir, glob.slice(1))}` : resolve(baseDir, glob),
+    );
 }
 
 /**
@@ -162,6 +169,10 @@ export async function loadInternalConfig(configPath?: string): Promise<LoadedCon
             }
 
             const internalConfig = fillDefaults(userConfig);
+            internalConfig.content = resolveContentGlobs(
+                internalConfig.content,
+                dirname(foundConfigPath),
+            );
             const validatedConfig = validateInternalConfig(internalConfig);
 
             return {

--- a/packages/core/src/shared/config.ts
+++ b/packages/core/src/shared/config.ts
@@ -81,6 +81,8 @@ export function fillDefaultsCore(userConfig: SugarcubeConfig, dirs: DefaultDirs)
             classes: userConfig.utilities?.classes,
         },
 
+        content: userConfig.content,
+
         components: userConfig.components ?? componentsDir,
 
         cube: userConfig.cube ?? stylesDir,

--- a/packages/core/src/shared/schemas/config.ts
+++ b/packages/core/src/shared/schemas/config.ts
@@ -141,6 +141,8 @@ export const userConfigSchema = z.object({
 
     utilities: utilitiesOutputConfigSchema.optional(),
 
+    content: z.array(z.string()).optional(),
+
     components: z.string().optional(),
 
     cube: z.string().optional(),
@@ -169,6 +171,8 @@ export const internalConfigSchema = z.object({
         layer: z.string().optional(),
         classes: utilityClassesSchema.optional(),
     }),
+
+    content: z.array(z.string()).optional(),
 
     components: z.string().optional(),
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -453,6 +453,15 @@ export interface SugarcubeConfig {
     utilities?: UtilitiesOutputConfig;
 
     /**
+     * Globs of source files scanned for token/utility usage.
+     *
+     * When omitted, scanning falls back to the working directory downward.
+     *
+     * @example content: ["./**\/*.{js,ts}", "../../lib/**\/*.heex"]
+     */
+    content?: string[];
+
+    /**
      * Directory path where component files will be copied.
      * @example "src/components/ui"
      */
@@ -499,6 +508,9 @@ export interface InternalConfig {
         layer?: string;
         classes?: UtilityClassesConfig;
     };
+
+    /** Globs scanned for token/utility usage (resolved to absolute at load) */
+    content?: string[];
 
     /** Directory path where component files will be copied */
     components?: string;

--- a/packages/core/tests/load-config.test.ts
+++ b/packages/core/tests/load-config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -43,6 +43,44 @@ describe("loadInternalConfig", () => {
             DEFAULT_CONFIG.variables.transforms.fluid.max,
         );
         expect(result.configPath).toContain("sugarcube.config.js");
+    });
+
+    it("resolves content globs against the config file's directory, not cwd", async () => {
+        const configDir = join(tempDir, "assets", "js");
+        await mkdir(configDir, { recursive: true });
+        const configContent = `
+            export default {
+                resolver: "./tokens.resolver.json",
+                content: ["../../lib/**/*.heex", "./**/*.js"],
+            };
+        `;
+        await writeFile(join(configDir, "sugarcube.config.js"), configContent);
+
+        const result = await loadInternalConfig(join("assets", "js", "sugarcube.config.js"));
+
+        expect(result.config.content).toEqual([
+            join(tempDir, "lib", "**", "*.heex"),
+            join(configDir, "**", "*.js"),
+        ]);
+    });
+
+    it("preserves a leading ! (negation) when resolving content globs", async () => {
+        const configDir = join(tempDir, "assets", "js");
+        await mkdir(configDir, { recursive: true });
+        const configContent = `
+            export default {
+                resolver: "./tokens.resolver.json",
+                content: ["../../lib/**/*.heex", "!../../lib/**/vendor/**"],
+            };
+        `;
+        await writeFile(join(configDir, "sugarcube.config.js"), configContent);
+
+        const result = await loadInternalConfig(join("assets", "js", "sugarcube.config.js"));
+
+        expect(result.config.content).toEqual([
+            join(tempDir, "lib", "**", "*.heex"),
+            `!${join(tempDir, "lib", "**", "vendor", "**")}`,
+        ]);
     });
 
     it("auto-discovers resolver when no config file exists", async () => {

--- a/packages/core/tests/normalize-config.test.ts
+++ b/packages/core/tests/normalize-config.test.ts
@@ -199,3 +199,19 @@ describe("validateConfig — variables.variableName", () => {
         ).toThrow(/variableName must be a function/);
     });
 });
+
+describe("validateConfig — content", () => {
+    it("carries user-specified content globs onto the internal config", () => {
+        const content = ["./**/*.heex", "../../lib/**/*.ex"];
+
+        const result = validateConfig(minimalConfig({ content }));
+
+        expect(result.content).toEqual(content);
+    });
+
+    it("leaves content undefined when omitted", () => {
+        const result = validateConfig(minimalConfig());
+
+        expect(result.content).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Adds content config so generate and lint can scan markup outside the working directory. Useful for frameworks/projects where sugarcube doesn't live/run top-down.